### PR TITLE
Disable default alias name admin box

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -35,14 +35,16 @@ class Document {
 			self::TAXONOMY_NAME,
 			self::TYPE_NAME,
 			[
-				'description'        => __( 'Taxonomy for saved GraphQL queries', 'wp-graphql-persisted-queries' ),
+				'description'        => __( 'Alias names for saved GraphQL queries', 'wp-graphql-persisted-queries' ),
 				'hierarchical'       => false,
 				'labels'             => [
-					'name'          => __( 'GraphQL Query Names', 'wp-graphql-persisted-queries' ),
-					'singular_name' => __( 'GraphQL Query Name', 'wp-graphql-persisted-queries' ),
+					'name'          => __( 'Alias Names', 'wp-graphql-persisted-queries' ),
+					'singular_name' => __( 'Alias Name', 'wp-graphql-persisted-queries' ),
 				],
-				'show_ui'            => true,
+				'show_admin_column'  => true,
+				'show_in_menu'       => false,
 				'show_in_quick_edit' => false,
+				'meta_box_cb'        => [ $this, 'admin_input_box_cb' ],
 			]
 		);
 		register_taxonomy_for_object_type( self::TAXONOMY_NAME, self::TYPE_NAME );
@@ -164,6 +166,30 @@ class Document {
 		}
 
 		return $post_id;
+	}
+
+	/**
+	 * Draw the input field for the post edit
+	 */
+	public function admin_input_box_cb( $post ) {
+		wp_nonce_field( 'graphql_query_grant', '_document_noncename' );
+
+		$html  = '<ul>';
+		$terms = get_the_terms( $post, self::TAXONOMY_NAME );
+
+		foreach ( $terms as $term ) {
+			$string = mb_strimwidth( $term->name, 0, 30, '...' );
+			$html  .= "<li>$string</li>";
+		}
+		$html .= '</ul>';
+		$html .= __( 'The aliases associated with this graphql document. Use in a graphql request as the queryId={} parameter', 'wp-graphql-persisted-queries' );
+		echo wp_kses(
+			$html,
+			[
+				'ul' => true,
+				'li' => true,
+			]
+		);
 	}
 
 }

--- a/src/Document/Grant.php
+++ b/src/Document/Grant.php
@@ -17,8 +17,8 @@ class Grant {
 	// The string value used for the individual saved query
 	const ALLOW                = 'allow';
 	const DENY                 = 'deny';
-	const USE_DEFAULT          = 'default';
-	const NOT_SELECTED_DEFAULT = false;
+	const USE_DEFAULT          = false;
+	const NOT_SELECTED_DEFAULT = self::USE_DEFAULT;
 
 	// The string value stored for the global admin setting
 	const GLOBAL_ALLOWED = 'only_allowed';
@@ -84,21 +84,21 @@ class Grant {
 		$html  = sprintf(
 			'<input type="radio" id="graphql_query_grant_allow" name="graphql_query_grant" value="%s" %s>',
 			self::ALLOW,
-			checked( $value, self::ALLOW, self::NOT_SELECTED_DEFAULT )
+			checked( $value, self::ALLOW, false )
 		);
-		$html .= '<label for="graphql_query_grant_allow">Allowed</label>&nbsp;';
+		$html .= '<label for="graphql_query_grant_allow">Allowed</label><br >';
 		$html .= sprintf(
 			'<input type="radio" id="graphql_query_grant_deny" name="graphql_query_grant" value="%s" %s>',
 			self::DENY,
-			checked( $value, self::DENY, self::NOT_SELECTED_DEFAULT )
+			checked( $value, self::DENY, false )
 		);
-		$html .= '<label for="graphql_query_grant_deny">Deny</label>&nbsp;';
+		$html .= '<label for="graphql_query_grant_deny">Deny</label><br >';
 		$html .= sprintf(
 			'<input type="radio" id="graphql_query_grant_default" name="graphql_query_grant" value="%s" %s>',
 			self::USE_DEFAULT,
-			checked( $value, self::USE_DEFAULT, self::NOT_SELECTED_DEFAULT )
+			checked( $value, self::USE_DEFAULT, false )
 		);
-		$html .= '<label for="graphql_query_grant_default">Use global default</label>&nbsp;';
+		$html .= '<label for="graphql_query_grant_default">Use global default</label><br >';
 		echo wp_kses(
 			$html,
 			[
@@ -109,6 +109,7 @@ class Grant {
 					'value'   => true,
 					'checked' => true,
 				],
+				'br'    => true,
 			]
 		);
 	}

--- a/tests/acceptance/DocumentDescriptionCest.php
+++ b/tests/acceptance/DocumentDescriptionCest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SaveQueryDescriptionCest
+class DocumentDescriptionCest
 {
     public function createQueryWithDescriptionTest(AcceptanceTester $I)
     {

--- a/tests/acceptance/DocumentGrantCest.php
+++ b/tests/acceptance/DocumentGrantCest.php
@@ -4,7 +4,7 @@
  * Test the allow/deny selection for individual query grant access.
  */
 
-class SaveQueryGrantCest
+class DocumentGrantCest
 {
     public function adminSetQueryToAllowAndDenyTest(AcceptanceTester $I)
     {
@@ -29,7 +29,7 @@ class SaveQueryGrantCest
         $I->assertEquals(
             'deny',
             $I->grabTextFrom(
-                sprintf( '//*[@id="post-%d"]/td[2]/a', $post_id )
+                sprintf( '//*[@id="post-%d"]/td[3]/a', $post_id )
             )
         );
     }


### PR DESCRIPTION
The Query Alias Names list and taxonomy add/remove interface in the admin ui is confusing.  For now, disable the ui and at minimal show the query alias names for each saved query.
![Screen Shot 2021-10-26 at 2 23 11 PM](https://user-images.githubusercontent.com/749603/138949393-b8f5ce21-a469-4019-9177-50555b0978b8.png)
![Screen Shot 2021-10-26 at 2 22 58 PM](https://user-images.githubusercontent.com/749603/138949400-fb2eeef2-1a4b-488d-a9d6-9322cd31fc02.png)


