### PR TITLE
Add wp-admin settings for graphql cache

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.17",
+            "version": "2.1.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "df5aba175a44c2996ced4edf8ec9f9081b5348c0"
+                "reference": "c4077e223d6da058a840a325bc4b48631892e3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/df5aba175a44c2996ced4edf8ec9f9081b5348c0",
-                "reference": "df5aba175a44c2996ced4edf8ec9f9081b5348c0",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/c4077e223d6da058a840a325bc4b48631892e3d0",
+                "reference": "c4077e223d6da058a840a325bc4b48631892e3d0",
                 "shasum": ""
             },
             "require": {
@@ -51,9 +51,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.17"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.18"
             },
-            "time": "2021-10-21T14:22:43+00:00"
+            "time": "2022-01-19T11:06:53+00:00"
         },
         {
             "name": "behat/gherkin",

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -17,6 +17,12 @@ class Settings {
 		return ( 'on' === $display_admin );
 	}
 
+	// Settings checkbox set to on to enable caching
+	public static function caching_enabled() {
+		$option = \get_graphql_setting( 'cache_toggle', false, 'graphql_cache_section' );
+		return ( 'on' === $option );
+	}
+
 	public function init() {
 		// Add to the wp-graphql admin settings page
 		add_action(
@@ -68,6 +74,25 @@ class Settings {
 						'name'    => 'editor_display',
 						'label'   => __( 'Display queries in admin editor', 'wp-graphql-labs' ),
 						'desc'    => __( 'Toggle to show queries in wp-admin left side menu', 'wp-graphql-labs' ),
+						'type'    => 'checkbox',
+						'default' => 'off',
+					]
+				);
+
+				// Add a tab section to the graphql admin settings page
+				register_graphql_settings_section(
+					'graphql_cache_section',
+					[
+						'title' => __( 'Cache', 'wp-graphql-labs' ),
+					]
+				);
+
+				register_graphql_settings_field(
+					'graphql_cache_section',
+					[
+						'name'    => 'cache_toggle',
+						'label'   => __( 'Enable results caching for improved speed', 'wp-graphql-labs' ),
+						'desc'    => __( 'Toggle to enable caching of graphql query results', 'wp-graphql-labs' ),
 						'type'    => 'checkbox',
 						'default' => 'off',
 					]

--- a/tests/functional/AdminSettingsCacheCest.php
+++ b/tests/functional/AdminSettingsCacheCest.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Test the wp-graphql settings page for cache
+ */
+
+class AdminSettingsCacheCest
+{
+	public function _after( FunctionalTester $I ) {
+		$I->dontHaveOptionInDatabase( 'graphql_cache_section'  );
+	}
+
+	public function selectCacheSettingsTest( FunctionalTester $I ) {
+			$I->loginAsAdmin();
+			$I->amOnPage('/wp-admin/admin.php?page=graphql#graphql_cache_section');
+
+			// Save and see the selection after form submit
+			$I->checkOption("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
+			$I->click('Save Changes');
+			$I->seeCheckboxIsChecked("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
+
+			$I->uncheckOption("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
+			$I->click('Save Changes');
+			$I->dontSeeCheckboxIsChecked("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
+	}
+
+}

--- a/tests/wpunit/AdminSettingsCacheTest.php
+++ b/tests/wpunit/AdminSettingsCacheTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WPGraphQL\PersistedQueries;
+
+use WPGraphQL\PersistedQueries\Admin\Settings;
+
+/**
+ * Test the wp-graphql request to cached query is faster
+ */
+
+class AdminSettingsCacheTest extends \Codeception\TestCase\WPTestCase {
+
+	public function _before() {
+		delete_option( 'graphql_cache_section' );
+	}
+
+	public function _after() {
+		delete_option( 'graphql_cache_section' );
+	}
+
+	public function testCacheSettingsOff() {
+		delete_option( 'graphql_cache_section' );
+		$this->assertFalse( Settings::caching_enabled() );
+
+		update_option( 'graphql_cache_section', [] );
+		$this->assertFalse( Settings::caching_enabled() );
+
+		update_option( 'graphql_cache_section', [ 'cache_toggle' => 'off' ] );
+		$this->assertFalse( Settings::caching_enabled() );
+
+		update_option( 'graphql_cache_section', [ 'cache_toggle' => false ] );
+		$this->assertFalse( Settings::caching_enabled() );
+	}
+
+	public function testCacheSettingsOn() {
+		add_option( 'graphql_cache_section', [ 'cache_toggle' => 'on' ] );
+		$this->assertTrue( Settings::caching_enabled() );
+	}
+}


### PR DESCRIPTION
As a wp site admin, I want to be able to toggle on/off use of wp-graphql query cache.

![Screen Shot 2022-01-19 at 11 11 41 AM](https://user-images.githubusercontent.com/749603/150194181-2600dd21-7aed-479c-a2fe-6a5d2d99383a.png)

<img width="646" alt="Screen Shot 2022-01-19 at 11 17 18 AM" src="https://user-images.githubusercontent.com/749603/150194190-9c723b68-d376-42d7-afac-5d70c76dce46.png">



closes https://github.com/wp-graphql/wp-graphql-labs/issues/77