### PR TITLE
On release publish, build zip file

### DIFF
--- a/.github/workflows/upload-plugin-zip.yml
+++ b/.github/workflows/upload-plugin-zip.yml
@@ -1,0 +1,27 @@
+name: Build plugin zip file
+on:
+  release:
+    types: [ published ]
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          tools: composer
+      - name: Install PHP dependencies
+        run: |
+          composer install --no-dev --optimize-autoloader
+      - name: Create Artifact
+        run: |
+          mkdir plugin-build
+          composer archive -vvv --format=zip --file="plugin-build/wp-graphql-labs"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wp-graphql-labs
+          path: plugin-build/wp-graphql-labs.zip

--- a/composer.json
+++ b/composer.json
@@ -46,18 +46,23 @@
       "php ./vendor/bin/phpcbf"
     ]
   },
-  "archive": {
-    "exclude": [
-      "*.yml",
-      "*.zip",
-      ".env*",
-      "docker/",
-      "!vendor/",
-      "tests/",
-      "!.wordpress-org/",
-      "wp-content/"
-    ]
-  },
+	"archive": {
+		"exclude": [
+			"*.yml",
+			"*.zip",
+			".env*",
+			"!.wordpress-org/",
+			"!build",
+			"docker/",
+			"docs/",
+			"node_modules/",
+			"packages",
+			"plugin-build/",
+			"tests/",
+			"!vendor/",
+			"wp-content/"
+		]
+	},
   "config": {
       "allow-plugins": {
           "dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
A new github action for when a release is published. Trigger the composer archive zip file build.
The zip file should be created with just the needed WP plugin files for run time. Without any dev files.
The zip file should then be visible and present on the releases page/view for download.