### PR TITLE
Explicit convert to array

### DIFF
--- a/src/Storage/WpCache.php
+++ b/src/Storage/WpCache.php
@@ -28,7 +28,12 @@ class WpCache {
 	 * @return bool False if value was not set and true if value was set.
 	 */
 	public function set( $key, $data, $expire ) {
-		return wp_cache_set( $key, $data, $this->group_name, $expire );
+		return wp_cache_set(
+			$key,
+			is_array( $data ) ? $data : $data->toArray(),
+			$this->group_name,
+			$expire
+		);
 	}
 
 	/**


### PR DESCRIPTION
The ExecutionResult object when using object-cache and this WpCache class, failed with fatal error on convert to array to save to cache.  

`"Serialization of 'Closure' is not allowed"`

