### PR TITLE
Make the GraphQL Document Post Type private

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -43,7 +43,6 @@ class Document {
 					'singular_name' => __( 'GraphQLQuery', 'wp-graphql-smart-cache' ),
 				],
 				'public'              => false,
-				'publicly_queryable'  => true,
 				'show_ui'             => Settings::show_in_admin(),
 				'taxonomies'          => [
 					self::ALIAS_TAXONOMY_NAME,


### PR DESCRIPTION
- remove the publicly_queryable=>true statement from the graphql_document post_type