### PR TITLE
Improve Cache-Control header implementation

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -99,13 +99,18 @@ class Settings {
 					'graphql_cache_section',
 					[
 						'name'              => 'global_max_age',
-						'label'             => __( 'Access-Control-Max-Age Header', 'wp-graphql-smart-cache' ),
-						'desc'              => __( 'Global Max-Age HTTP header. Integer value, greater or equal to zero.', 'wp-graphql-smart-cache' ),
+						'label'             => __( 'Cache-Control max-age', 'wp-graphql-smart-cache' ),
+						'desc'              => __( 'If set, a Cache-Control header with max-age directive will be set for all GraphQL responses. Value should be an integer, greater or equal to zero, or blank to disable. A value of 0 indicates that requests should not be cached (use with caution).', 'wp-graphql-smart-cache' ),
 						'type'              => 'number',
 						'sanitize_callback' => function ( $value ) {
-							if ( $value < 0 || ! is_numeric( $value ) ) {
+							if ( ! is_numeric( $value ) ) {
+								return null;
+							}
+
+							if ( $value < 0 ) {
 								return 0;
 							}
+
 							return (int) $value;
 						},
 					]

--- a/src/Document/MaxAge.php
+++ b/src/Document/MaxAge.php
@@ -23,7 +23,7 @@ class MaxAge {
 			self::TAXONOMY_NAME,
 			Document::TYPE_NAME,
 			[
-				'description'        => __( 'HTTP Access-Control-Max-Age Header for a saved GraphQL document', 'wp-graphql-smart-cache' ),
+				'description'        => __( 'HTTP Cache-Control max-age directive for a saved GraphQL document', 'wp-graphql-smart-cache' ),
 				'labels'             => [
 					'name' => __( 'Max-Age Header', 'wp-graphql-smart-cache' ),
 				],
@@ -46,7 +46,7 @@ class MaxAge {
 				$register_type_name = ucfirst( Document::GRAPHQL_NAME );
 				$config             = [
 					'type'        => 'Int',
-					'description' => __( 'HTTP Access-Control-Max-Age Header for a saved GraphQL document', 'wp-graphql-smart-cache' ),
+					'description' => __( 'HTTP Cache-Control max-age directive for a saved GraphQL document', 'wp-graphql-smart-cache' ),
 				];
 
 				register_graphql_field( 'Create' . $register_type_name . 'Input', 'max_age_header', $config );
@@ -186,10 +186,14 @@ class MaxAge {
 			$age = get_graphql_setting( 'global_max_age', null, 'graphql_cache_section' );
 		}
 
-		// Access-Control-Max-Age header should be zero or positive integer, no decimals.
+		// Cache-Control max-age directive should be a positive integer, no decimals.
+		// A value of zero indicates that caching should be disabled.
 		if ( $this->valid( $age ) ) {
-			$headers['Access-Control-Max-Age'] = intval( $age );
-			$headers['Cache-Control']          = sprintf( 'max-age=%1$s, s-maxage=%1$s, must-revalidate', intval( $age ) );
+			if ( 0 === $age ) {
+				$headers['Cache-Control'] = 'no-store';
+			} else {
+				$headers['Cache-Control'] = sprintf( 'max-age=%1$s, s-maxage=%1$s, must-revalidate', intval( $age ) );
+			}
 		}
 
 		return $headers;

--- a/tests/wpunit/BatchQueryTest.php
+++ b/tests/wpunit/BatchQueryTest.php
@@ -49,7 +49,7 @@ class BatchQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 
 		// Test saved/persisted query.
 		$query_string = sprintf( "query %s { posts { nodes { uri id databaseId } } }", $this->query_alias );
-		$query = 
+		$query =
 			[
 				[	"queryId" => $this->query_alias ],
 				[	"query" => $query_string ],
@@ -115,6 +115,6 @@ class BatchQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$max_age->peek_at_executing_query_cb( '', json_decode( json_encode( $request ) ) );
 
 		$headers = $max_age->http_headers_cb( [] );
-		$this->assertEquals( 10, $headers[ 'Access-Control-Max-Age' ] );
+		$this->assertEquals( 'max-age=10, s-maxage=10, must-revalidate', $headers[ 'Cache-Control' ] );
 	}
 }


### PR DESCRIPTION
Hello! Great work on this plugin. I'm digging in and building a integration with WordPress VIP's platform to automatically purge page cache when this plugin is in use.

This PR introduces a few changes:

- Remove references to and control over the [`Access-Control-Max-Age` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age), which is a CORS response header. This header has nothing to do with whether a response body is cached by the browser or any other cache. It would be unexpected for this plugin to change the global CORS behavior of WPGraphQL.

- Improve the validation of the `global_max_age` option. Currently, an empty input is coerced to `0` on save, making it very easy for a plugin user to accidentally disable caching without realizing it.

- Improve the implementation and awareness of a `0` value. The assumed intention of `0` max-age is to disable caching; this change makes that intention clear in the description and implements it using `no-store` instead of `max-age=0` ([context](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)).
