### PR TITLE
v0.2.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,18 +1,45 @@
-=== WP GraphQL Persisted Queries ===
+=== WPGraphQL Smart Cache ===
 Contributors: markkelnar, jasonbahl
 Tags: GraphQL
 Requires at least: 4.5
 Tested up to: 5.6.1
 Requires PHP: 5.6
-Stable tag: 0.1.2
+Stable tag: 0.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-WPGraphQL Persisted Queries for WPGraphQL, a plugin that provides an extendable GraphQL schema and API for any WordPress site.
+**BREAKING CHANGE DISCLAIMER:** While this plugin is tested and used in production, as we iterate we expect breaking changes. Not so much to surface functionality (unless required), but definitely expect changes to underlying code, class/function/filter names as we continue to receive feedback and workout details..
+
+WPGraphQL Smart Cache is a plugin that provides WPGraphQL users with cache and cache invalidation options. The plugin also provides Persisted Query support.
+
+== Upgrade Notice ==
+
+= 0.2.0 =
+
+This release removes a lot of code that has since been released as part of WPGraphQL core.
+
+In order to use v0.2.0+ of WPGraphQL Smart Cache, you will need WPGraphQL v1.12.0 or newer.
 
 == Changelog ==
+
+= 0.2.0
+
+- chore: remove unreferenced .zip build artifact
+- feat: remove a lot of logic from Collection.php that analyzes queries to generate cache keys and response headers, as this has been moved to core WPGraphQL
+- feat: reference core WPGraphQL functions for storing cache maps for object caching
+- chore: remove unused "use" statements in Invalidation.php
+- feat: introduce new "graphql_purge" action, which can be hooked into by caching clients to purge caches by key
+- chore: remove $collection->node_key() method and references to it.
+- feat: add "purge("skipped:$type_name)" event when purge_nodes is called
+- chore: remove model class prefixes from purge_nodes() calls
+- chore: rename const WPGRAPHQL_LABS_PLUGIN_DIR to WPGRAPHQL_SMART_CACHE_PLUGIN_DIR
+- chore: update tests to remove "node:" prefix from expected keys
+- chore: update tests to use self::factory() instead of $this->tester->factory()
+- chore: update Plugin docblock
+- feat: add logic to ensure minimum version of WPGraphQL is active before executing functionality needed by it
+- chore: remove filters that add model definitions to Types as that's been moved to WPGraphQL core
 
 = 0.1.2 =
 

--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -11,7 +11,7 @@
  * Requires PHP: 7.4
  * Text Domain: wp-graphql-smart-cache
  * Domain Path: /languages
- * Version: 0.1.2
+ * Version: 0.2.0
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '1.2.0';
-const WPGRAPHQL_SMART_CACHE_VERSION  = '0.1.2';
+const WPGRAPHQL_SMART_CACHE_VERSION  = '0.2.0';
 
 require __DIR__ . '/vendor/autoload.php';
 


### PR DESCRIPTION
- chore: remove unreferenced .zip build artifact
- feat: remove a lot of logic from Collection.php that analyzes queries to generate cache keys and response headers, as this has been moved to core WPGraphQL
- feat: reference core WPGraphQL functions for storing cache maps for object caching
- chore: remove unused "use" statements in Invalidation.php
- feat: introduce new "graphql_purge" action, which can be hooked into by caching clients to purge caches by key
- chore: remove $collection->node_key() method and references to it.
- feat: add "purge("skipped:$type_name)" event when purge_nodes is called
- chore: remove model class prefixes from purge_nodes() calls
- chore: rename const WPGRAPHQL_LABS_PLUGIN_DIR to WPGRAPHQL_SMART_CACHE_PLUGIN_DIR
- chore: update tests to remove "node:" prefix from expected keys
- chore: update tests to use self::factory() instead of $this->tester->factory()
- chore: update Plugin docblock
- feat: add logic to ensure minimum version of WPGraphQL is active before executing functionality needed by it
- chore: remove filters that add model definitions to Types as that's been moved to WPGraphQL core