### PR TITLE
Better queryId support for query analyzer

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -178,10 +178,10 @@ class Document {
 
 		// if the query is empty, but the queryId is set
 		if ( empty( $parsed_body_params['query'] ) && ! empty( $parsed_body_params['queryId'] ) ) {
-			$query_id = $parsed_body_params['queryId'] ?: null;
+			$query_id     = $parsed_body_params['queryId'] ?: null;
 			$query_string = $this->get( $query_id );
 			if ( ! empty( $query_string ) ) {
-				$parsed_body_params['query'] = $query_string;
+				$parsed_body_params['query']           = $query_string;
 				$parsed_body_params['originalQueryId'] = $query_id;
 				unset( $parsed_body_params['queryId'] );
 			}

--- a/src/Document.php
+++ b/src/Document.php
@@ -178,11 +178,10 @@ class Document {
 
 		// if the query is empty, but the queryId is set
 		if ( empty( $parsed_body_params['query'] ) && ! empty( $parsed_body_params['queryId'] ) ) {
-			$query_id     = $parsed_body_params['queryId'] ?: null;
-			$query_string = $this->get( $query_id );
+			$query_string = $this->get( $parsed_body_params['queryId'] );
 			if ( ! empty( $query_string ) ) {
 				$parsed_body_params['query']           = $query_string;
-				$parsed_body_params['originalQueryId'] = $query_id;
+				$parsed_body_params['originalQueryId'] = $parsed_body_params['queryId'];
 				unset( $parsed_body_params['queryId'] );
 			}
 		}

--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -189,12 +189,21 @@ add_action(
 	}
 );
 
-add_action( 'graphql_purge', function( $purge_keys ) {
-	if ( ! function_exists( 'graphql_get_endpoint_url' ) || ! method_exists( 'WpeCommon', 'http_to_varnish' ) ) {
-		return;
-	}
-	\WpeCommon::http_to_varnish( 'PURGE_GRAPHQL', null, [
-		'GraphQL-Purge-Keys' => $purge_keys,
-		'GraphQL-URL' => graphql_get_endpoint_url(),
-	] );
-}, 0, 1 );
+add_action(
+	'graphql_purge',
+	function ( $purge_keys ) {
+		if ( ! function_exists( 'graphql_get_endpoint_url' ) || ! method_exists( 'WpeCommon', 'http_to_varnish' ) ) {
+			return;
+		}
+		\WpeCommon::http_to_varnish(
+			'PURGE_GRAPHQL',
+			null,
+			[
+				'GraphQL-Purge-Keys' => $purge_keys,
+				'GraphQL-URL'        => graphql_get_endpoint_url(),
+			]
+		);
+	},
+	0,
+	1
+);


### PR DESCRIPTION
This adds support for the x-graphql-key headers to work when a query is referenced by queryId

When querying via queryId, most headers related to caching are missing. This PR fixes that.

**Before**

Querying for a query using a `queryId` only returns the `graphql:Query` X-Key header, and doesn't include the node/list/queryId, keys.

![CleanShot 2022-10-19 at 12 24 00](https://user-images.githubusercontent.com/1260765/196773670-94ea71b6-ac2f-4133-b7b4-1ebc89e00966.png)


**After**

After this PR, the node/list/queryId keys are properly output with the response.

![CleanShot 2022-10-19 at 12 25 49](https://user-images.githubusercontent.com/1260765/196773985-963c90d2-8f8f-456b-b0ee-69e2907b4534.png)
