### PR TITLE
feat: add new "graphql_cache_is_object_cache_inabled" filter 

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -30,7 +30,6 @@ class Invalidation {
 	 * Initialize the actions to listen for
 	 */
 	public function init() {
-
 		// @phpcs:ignore
 		do_action( 'graphql_cache_invalidation_init', $this );
 

--- a/src/Cache/Results.php
+++ b/src/Cache/Results.php
@@ -6,6 +6,8 @@
 
 namespace WPGraphQL\SmartCache\Cache;
 
+use WPGraphQL;
+use WPGraphQL\Request;
 use WPGraphQL\SmartCache\Admin\Settings;
 
 class Results extends Query {
@@ -18,6 +20,11 @@ class Results extends Query {
 	 * @array bool
 	 */
 	protected $is_cached = [];
+
+	/**
+	 * @var
+	 */
+	protected $request;
 
 	public function init() {
 		add_filter( 'pre_graphql_execute_request', [ $this, 'get_query_results_from_cache_cb' ], 10, 2 );
@@ -92,17 +99,20 @@ class Results extends Query {
 	/**
 	 * Look for a 'cached' response for this exact query, variables and operation name
 	 *
-	 * @param mixed|array|object $result The response from execution. Array for batch requests,
+	 * @param mixed|array|object $result   The response from execution. Array for batch requests,
 	 *                                     single object for individual requests
-	 * @param WPGraphql/Request $request The Request object
+	 * @param Request            $request
 	 *
 	 * @return mixed|array|object|null  The response or null if not found in cache
 	 */
-	public function get_query_results_from_cache_cb( $result, $request ) {
+	public function get_query_results_from_cache_cb( $result, Request $request ) {
+
+		$this->request = $request;
+
 		// if caching is not enabled or the request is authenticated, bail early
 		// right now we're not supporting GraphQL cache for authenticated requests.
 		// Possibly in the future.
-		if ( ! Settings::caching_enabled() || is_user_logged_in() ) {
+		if ( ! $this->is_object_cache_enabled() ) {
 			return $result;
 		}
 
@@ -157,16 +167,22 @@ class Results extends Query {
 	 * @return bool
 	 */
 	protected function is_object_cache_enabled() {
-		if ( is_user_logged_in() ) {
-			return false;
-		}
+
+		// default to disabled
+		$enabled = false;
 
 		// if caching is enabled, respect it
 		if ( Settings::caching_enabled() ) {
-			return true;
+			$enabled = true;
 		}
 
-		return false;
+		// however, if the user is logged in, we should bypass the cache
+		if ( is_user_logged_in() ) {
+			$enabled = false;
+		}
+
+		// @phpcs:ignore
+		return (bool) apply_filters( 'graphql_cache_is_object_cache_enabled', $enabled, $this->request );
 	}
 
 	/**
@@ -214,7 +230,7 @@ class Results extends Query {
 			return;
 		}
 
-		// If do not have a cached version, or it expired, save the results again with new expiration
+		// If we do not have a cached version, or it expired, save the results again with new expiration
 		$cached_result = $this->get( $key );
 
 		if ( false === $cached_result ) {
@@ -231,7 +247,7 @@ class Results extends Query {
 	 * @return bool True on success, false on failure.
 	 */
 	public function purge_all() {
-		if ( ! Settings::caching_enabled() ) {
+		if ( ! $this->is_object_cache_enabled() ) {
 			return false;
 		}
 

--- a/src/Cache/Results.php
+++ b/src/Cache/Results.php
@@ -246,10 +246,6 @@ class Results extends Query {
 	 * @return bool True on success, false on failure.
 	 */
 	public function purge_all() {
-		if ( ! $this->is_object_cache_enabled() ) {
-			return false;
-		}
-
 		return parent::purge_all();
 	}
 

--- a/src/Cache/Results.php
+++ b/src/Cache/Results.php
@@ -106,7 +106,6 @@ class Results extends Query {
 	 * @return mixed|array|object|null  The response or null if not found in cache
 	 */
 	public function get_query_results_from_cache_cb( $result, Request $request ) {
-
 		$this->request = $request;
 
 		// if caching is not enabled or the request is authenticated, bail early

--- a/src/Cache/Results.php
+++ b/src/Cache/Results.php
@@ -240,16 +240,6 @@ class Results extends Query {
 	}
 
 	/**
-	 * Searches the database for all graphql transients matching our prefix
-	 *
-	 * @return int|false  Count of the number deleted. False if error, nothing to delete or caching not enabled.
-	 * @return bool True on success, false on failure.
-	 */
-	public function purge_all() {
-		return parent::purge_all();
-	}
-
-	/**
 	 * When an item changed and this callback is triggered to delete results we have cached for that list of nodes
 	 * Related to the data type that changed.
 	 */

--- a/tests/functional/AdminSettingsGrantCest.php
+++ b/tests/functional/AdminSettingsGrantCest.php
@@ -23,7 +23,7 @@ class AdminSettingsGrantCest
 	}
 
 	public function testChangeAllowTriggersPurge( FunctionalTester $I ) {
-		$I->wantTo( 'Change the allow/deny grant glopbal setting and verify cache is purged' );
+		$I->wantTo( 'Change the allow/deny grant global setting and verify cache is purged' );
 
 		// Enable caching for this test
 		$I->haveOptionInDatabase( 'graphql_cache_section', [ 'cache_toggle' => 'on' ] );

--- a/tests/wpunit/CachedQueryTest.php
+++ b/tests/wpunit/CachedQueryTest.php
@@ -164,7 +164,7 @@ class CachedQueryTest extends \Codeception\TestCase\WPTestCase {
 
 		$results_object = new Results();
 		$response = $results_object->purge_all();
-		$this->assertFalse( $response );
+		$this->assertNotFalse( $response );
 	}
 
 	public function testPurgeCacheWhenNothingCached() {


### PR DESCRIPTION
This PR adds a new `graphql_cache_is_object_cache_inabled` filter that can allow 3rd party developers to dynamically enable/disable the object cache.

For example, (as mentioned in #177) a query param in the request, such as `?disable_cache` could be read by this filter and disable the cache for that request. 

This filter could be used like so:

```php
add_filter( 'graphql_cache_is_object_cache_enabled', function( $enabled, $request ) {
  
  // disable caching when `?disable_cache` is included as a query param
  if (
        $_SERVER['REQUEST_METHOD'] === 'POST' &&
        isset( $_REQUEST['disable_cache'] )
    ) {
      return false;
    }

  return $enabled;
}, 10, 2 );
```