### PR TITLE
fix: prevent error when users install the plugin from Composer

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -30,7 +30,6 @@ class Invalidation {
 	 * Initialize the actions to listen for
 	 */
 	public function init() {
-
 		// @phpcs:ignore
 		do_action( 'graphql_cache_invalidation_init', $this );
 

--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -26,8 +26,6 @@ use WPGraphQL\SmartCache\Cache\Invalidation;
 use WPGraphQL\SmartCache\Cache\Results;
 use WPGraphQL\SmartCache\Admin\Editor;
 use WPGraphQL\SmartCache\Admin\Settings;
-use WPGraphQL\SmartCache\Document;
-use WPGraphQL\SmartCache\Document;
 use WPGraphQL\SmartCache\Document\Description;
 use WPGraphQL\SmartCache\Document\Grant;
 use WPGraphQL\SmartCache\Document\MaxAge;

--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -26,6 +26,8 @@ use WPGraphQL\SmartCache\Cache\Invalidation;
 use WPGraphQL\SmartCache\Cache\Results;
 use WPGraphQL\SmartCache\Admin\Editor;
 use WPGraphQL\SmartCache\Admin\Settings;
+use WPGraphQL\SmartCache\Document;
+use WPGraphQL\SmartCache\Document;
 use WPGraphQL\SmartCache\Document\Description;
 use WPGraphQL\SmartCache\Document\Grant;
 use WPGraphQL\SmartCache\Document\MaxAge;
@@ -38,7 +40,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '1.2.0';
 const WPGRAPHQL_SMART_CACHE_VERSION  = '0.3.1';
 
-require __DIR__ . '/vendor/autoload.php';
+// If the autoload file exists, require it.
+// If the plugin was installed from composer, the autoload
+// would be required elsewhere in the project
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require __DIR__ . '/vendor/autoload.php';
+}
 
 if ( ! defined( 'WPGRAPHQL_SMART_CACHE_PLUGIN_DIR' ) ) {
 	define( 'WPGRAPHQL_SMART_CACHE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
@@ -55,6 +62,11 @@ function can_load_plugin() {
 
 	// Is WPGraphQL active?
 	if ( ! class_exists( 'WPGraphQL' ) ) {
+		return false;
+	}
+
+	// If the Document class doesn't exist, then the autoloader failed to load
+	if ( ! class_exists( Document::class ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
When installing the plugin from Composer, the autoload.php will exist in the project installing the plugin, not in the plugin itself. 

This wraps the the autoload `require` in a `file_exists()` check before requiring the local plugin autoload.

Additionally, this adds a check for the `Document` class in the `can_load_plugin` function to ensure the autoloaded classes exist before using them.

Closes #176 