### PR TITLE
fix: rename constant name for min required version of WPGraphQL

### DIFF
--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -162,7 +162,7 @@ function show_admin_notice() {
 				<p>
 					<?php
 					// translators: placeholder is the version number of the WPGraphQL Plugin that this plugin depends on
-					$text = sprintf( 'WPGraphQL (v%s+) must be active for "wp-graphql-smart-cache" to work', WPGRAPHQL_REQUIRED_MIN_VERSION );
+					$text = sprintf( 'WPGraphQL (v%s+) must be active for "wp-graphql-smart-cache" to work', WPGRAPHQL_SMART_CACHE_WPGRAPHQL_REQUIRED_MIN_VERSION );
 
 					// phpcs:ignore
 					esc_html_e( $text, 'wp-graphql-smart-cache' );


### PR DESCRIPTION
All the other constants were renamed in https://github.com/wp-graphql/wp-graphql-smart-cache/pull/188 except for this one.