### PR TITLE
Add action on purge-all to send purge to WPE varnish

### DIFF
--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -227,6 +227,25 @@ add_action(
 	1
 );
 
+add_action(
+	'wpgraphql_cache_purge_all',
+	function ( $purge_keys ) {
+		if ( ! function_exists( 'graphql_get_endpoint_url' ) || ! class_exists( 'WpeCommon' ) || ! method_exists( 'WpeCommon', 'http_to_varnish' ) ) {
+			return;
+		}
+		\WpeCommon::http_to_varnish(
+			'PURGE_GRAPHQL',
+			null,
+			[
+				'GraphQL-Purge-Keys' => 'graphql:Query',
+				'GraphQL-URL'        => graphql_get_endpoint_url(),
+			]
+		);
+	},
+	0,
+	1
+);
+
 /**
  * Initialize the plugin tracker
  *


### PR DESCRIPTION
For purge_all action, send purge to varnish for the highest level graphql hash key.  Expecting varnish cache to invalidate all cached graphql queries for the domain/endpoint.

re: [issue](https://github.com/wp-graphql/wp-graphql-smart-cache/issues/193)