### PR TITLE
fix: mutations shouldn't be cached

### DIFF
--- a/tests/functional/MutationsCest.php
+++ b/tests/functional/MutationsCest.php
@@ -1,0 +1,77 @@
+<?php
+
+class MutationsCest {
+
+	public $post_id;
+
+	public function _before( FunctionalTester $I ) {
+		$this->post_id = $I->havePostInDatabase( [ 'post_title' => 'test post' ] );
+	}
+
+	public function mutationShouldNotBeCachedTest( FunctionalTester $I ) {
+
+		$I->wantTo( 'Execute a mutation without it being cached' );
+
+		$I->haveOptionInDatabase( 'graphql_cache_section', [ 'cache_toggle' => 'on' ] );
+
+		$query = '
+		mutation CreateComment($input: CreateCommentInput!) {
+		  createComment(input: $input) {
+		    clientMutationId
+		  }
+		}
+		';
+
+		$clientMutationId = uniqid( 'test', true );
+
+		$variables = [
+			'input' => [
+				'clientMutationId' => $clientMutationId,
+				'commentOn' => $this->post_id,
+				'author' => 'test author',
+			],
+		];
+
+		$I->sendPost( 'graphql', [
+			'query' => $query,
+			'variables' => $variables
+		] );
+
+		$I->seeResponseContainsJson([
+			'data' => [
+				'createComment' => [
+					'clientMutationId' => $clientMutationId,
+				],
+			],
+		]);
+
+		$cache_response = $I->grabDataFromResponseByJsonPath( '$.extensions.graphqlSmartCache.graphqlObjectCache' );
+
+		codecept_debug($cache_response[0]);
+
+		$I->assertEmpty( $cache_response[0] );
+
+		$I->sendPost( 'graphql', [
+			'query' => $query,
+			'variables' => $variables,
+		] );
+
+		$I->seeResponseContainsJson([
+			'data' => [
+				'createComment' => [
+					'clientMutationId' => $clientMutationId,
+				],
+			],
+		]);
+
+		// this fails because there is a message
+		// output when the response has been served from the cache.
+		// If this is empty, then the response was _not_ served by the cache.
+		$cache_response = $I->grabDataFromResponseByJsonPath( '$.extensions.graphqlSmartCache.graphqlObjectCache' );
+
+
+		$I->assertEmpty( $cache_response[0] );
+
+	}
+
+}

--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -62,7 +62,7 @@ if ( ! defined( 'WPGRAPHQL_SMART_CACHE_PLUGIN_DIR' ) ) {
  * @return bool
  * @since 0.3
  */
-function graphql_smart_cache_can_load_plugin() {
+function can_load_plugin() {
 
 	// Is WPGraphQL active?
 	if ( ! class_exists( 'WPGraphQL' ) ) {
@@ -111,7 +111,7 @@ add_action(
 		/**
 		 * If WPGraphQL is not active, or is an incompatible version, show the admin notice and bail
 		 */
-		if ( false === graphql_smart_cache_can_load_plugin() ) {
+		if ( false === can_load_plugin() ) {
 			// Show the admin notice
 			add_action( 'admin_init', __NAMESPACE__ . '\show_admin_notice' );
 
@@ -177,7 +177,7 @@ function show_admin_notice() {
 add_action(
 	'admin_init',
 	function () {
-		if ( false === graphql_smart_cache_can_load_plugin() ) {
+		if ( false === can_load_plugin() ) {
 			return;
 		}
 
@@ -190,7 +190,7 @@ add_action(
 add_action(
 	'wp_loaded',
 	function () {
-		if ( false === graphql_smart_cache_can_load_plugin() ) {
+		if ( false === can_load_plugin() ) {
 			return;
 		}
 

--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -62,7 +62,7 @@ if ( ! defined( 'WPGRAPHQL_SMART_CACHE_PLUGIN_DIR' ) ) {
  * @return bool
  * @since 0.3
  */
-function can_load_plugin() {
+function graphql_smart_cache_can_load_plugin() {
 
 	// Is WPGraphQL active?
 	if ( ! class_exists( 'WPGraphQL' ) ) {
@@ -111,7 +111,7 @@ add_action(
 		/**
 		 * If WPGraphQL is not active, or is an incompatible version, show the admin notice and bail
 		 */
-		if ( false === can_load_plugin() ) {
+		if ( false === graphql_smart_cache_can_load_plugin() ) {
 			// Show the admin notice
 			add_action( 'admin_init', __NAMESPACE__ . '\show_admin_notice' );
 
@@ -177,7 +177,7 @@ function show_admin_notice() {
 add_action(
 	'admin_init',
 	function () {
-		if ( false === can_load_plugin() ) {
+		if ( false === graphql_smart_cache_can_load_plugin() ) {
 			return;
 		}
 
@@ -190,7 +190,7 @@ add_action(
 add_action(
 	'wp_loaded',
 	function () {
-		if ( false === can_load_plugin() ) {
+		if ( false === graphql_smart_cache_can_load_plugin() ) {
 			return;
 		}
 


### PR DESCRIPTION
The goal of this PR is to fix a bug where mutations are being cached. Mutations should not be cached. 

This adds a (failing) test which should help guide us to a solution.