### PR TITLE
Fix: ErrorException Warning: Attempt to read property "post_type" on null

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -678,7 +678,7 @@ class Invalidation {
 		$post = get_post( $post_id );
 
 		// if the post is not found or the post type is not nav menu item, ignore it
-		if ( !$post || 'nav_menu_item' !== $post->post_type ) {
+		if ( ! $post || 'nav_menu_item' !== $post->post_type ) {
 			return;
 		}
 


### PR DESCRIPTION
**ErrorException**
`Warning: Attempt to read property "post_type" on null
`
In this updated code, the condition $post checks whether the $post variable is not null before accessing its post_type property. If $post is null, the code immediately returns without attempting to access its properties.



