### PR TITLE
add: fix for empty post id's

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -523,6 +523,11 @@ class Invalidation {
 		// get the post object being modified
 		$post = get_post( $post_id );
 
+		// Check if $post_id is valid: Make sure that $post_id is a valid post ID. 
+		if ( ! post_exists( $post_id ) ) {
+			return;
+		}
+		
 		// if the post type is not tracked, ignore it
 		if ( ! in_array( $post->post_type, \WPGraphQL::get_allowed_post_types(), true ) ) {
 			return;


### PR DESCRIPTION
![Screenshot 2023-04-18 at 9 29 40](https://user-images.githubusercontent.com/12534341/232690470-91bd93d9-aefd-4fc5-8089-ea6aae758f92.png)

Fixing:

**ErrorException**
Warning: Attempt to read property `"post_type"` on null.

**Solution:**

> The error message you are seeing suggests that the $post object is null, which means that it was not able to retrieve the post object using the get_post() function.

Here are a few things you can try to resolve this issue:

Check if `$post_id` is valid: Make sure that `$post_id `is a valid post ID. You can check if it is by using the` post_exists() function:`