### PR TITLE
fix: ignore purging after updates to "apple_news_notice" meta key

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -18,6 +18,11 @@ class Invalidation {
 	public $collection = [];
 
 	/**
+	 * @var array | null
+	 */
+	protected static $ignored_meta_keys = null;
+
+	/**
 	 * Instantiate the Cache Invalidation class
 	 *
 	 * @param Collection $collection
@@ -110,6 +115,33 @@ class Invalidation {
 	}
 
 	/**
+	 * Return a list of ignored meta keys
+	 *
+	 * @return array|null
+	 */
+	public static function get_ignored_meta_keys() {
+
+		if ( null !== self::$ignored_meta_keys ) {
+			return self::$ignored_meta_keys;
+		}
+
+		// Default list of ignored meta keys
+		$ignored_meta_keys = [
+			// see: https://github.com/wp-graphql/wp-graphql-smart-cache/issues/206
+			'apple_news_notice'
+		];
+
+		$ignored_meta_keys = apply_filters( 'graphql_cache_ignored_meta_keys', $ignored_meta_keys );
+
+		// make sure the filter returns an array
+		self::$ignored_meta_keys = is_array( $ignored_meta_keys ) ? $ignored_meta_keys : [];
+
+		// return the ignored meta keys array
+		return self::$ignored_meta_keys;
+
+	}
+
+	/**
 	 * Determines whether the meta should be tracked or not.
 	 *
 	 * By default, meta keys that start with an underscore are treated as
@@ -141,6 +173,11 @@ class Invalidation {
 		// If the filter has been applied return it
 		if ( null !== $should_track ) {
 			return (bool) $should_track;
+		}
+
+		// If the meta key is ignored, don't track it for cache purging
+		if ( in_array( $meta_key, self::get_ignored_meta_keys(), true ) ) {
+			return false;
 		}
 
 		// If the meta key starts with an underscore, don't track it

--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -120,7 +120,6 @@ class Invalidation {
 	 * @return array|null
 	 */
 	public static function get_ignored_meta_keys() {
-
 		if ( null !== self::$ignored_meta_keys ) {
 			return self::$ignored_meta_keys;
 		}
@@ -128,7 +127,7 @@ class Invalidation {
 		// Default list of ignored meta keys
 		$ignored_meta_keys = [
 			// see: https://github.com/wp-graphql/wp-graphql-smart-cache/issues/206
-			'apple_news_notice'
+			'apple_news_notice',
 		];
 
 		$ignored_meta_keys = apply_filters( 'graphql_cache_ignored_meta_keys', $ignored_meta_keys );
@@ -138,7 +137,6 @@ class Invalidation {
 
 		// return the ignored meta keys array
 		return self::$ignored_meta_keys;
-
 	}
 
 	/**

--- a/tests/wpunit/UserCacheInvalidationTest.php
+++ b/tests/wpunit/UserCacheInvalidationTest.php
@@ -285,4 +285,18 @@ class UserCacheInvalidationTest extends \TestCase\WPGraphQLSmartCache\TestCase\W
 	    $this->assertEmpty( $evicted );
     }
 
+	// update user meta (with ignored meta key)
+	public function testUpdateIgnoredUserMetaAndPurgeCache() {
+
+		// re-populate the caches since we just ran an action that would evict caches
+		$this->_populateCaches();
+
+		// add some meta to the user to start
+		update_user_meta( $this->editor->ID, 'apple_news_notice', uniqid( null, true ) );
+
+		$evicted = $this->getEvictedCaches();
+
+		$this->assertEmpty( $evicted );
+	}
+
 }


### PR DESCRIPTION
This ensures that updates to the "apple_news_notice" meta key do not trigger cache purges. 

closes: #206

- Failing test: https://github.com/wp-graphql/wp-graphql-smart-cache/actions/runs/4734838056/jobs/8404287632#step:8:5613
- Passing test:  https://github.com/wp-graphql/wp-graphql-smart-cache/actions/runs/4734919202/jobs/8404484191?pr=207#step:8:6015