### PR TITLE
fix: post_exists() PHP fatal error

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -558,11 +558,11 @@ class Invalidation {
 		// get the post object being modified
 		$post = get_post( $post_id );
 
-		// Check if $post_id is valid: Make sure that $post_id is a valid post ID. 
-		if ( ! post_exists( $post_id ) ) {
+		// Make sure that $post is a valid post object.
+		if ( empty( $post ) ) {
 			return;
 		}
-		
+
 		// if the post type is not tracked, ignore it
 		if ( ! in_array( $post->post_type, \WPGraphQL::get_allowed_post_types(), true ) ) {
 			return;


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/wp-graphql/wp-graphql-smart-cache/commit/9fbf4821f2808ac7a5b4e153d98ba3a968d261da where `post_exists()` triggers a `Call to undefined function WPGraphQL\SmartCache\Cache\post_exists()` PHP fatal error.

We can instead use the result of the `get_post()` function to check if the ID belongs to a valid post.