### PR TITLE
fix: post_exists error

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -130,6 +130,7 @@ class Invalidation {
 			'apple_news_notice',
 		];
 
+		//phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$ignored_meta_keys = apply_filters( 'graphql_cache_ignored_meta_keys', $ignored_meta_keys );
 
 		// make sure the filter returns an array


### PR DESCRIPTION
This fixes an error that occurs by calling the `post_exists()` function even though it's not included during graphql requests. 

Instead, we check if the post object is an instance of a post. 

closes #209 