### PR TITLE
release: v1.0.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: WPGraphQL, Cache, API, Invalidation, Persisted Queries, GraphQL, Performan
 Requires at least: 5.6
 Tested up to: 6.1
 Requires PHP: 7.4
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -72,6 +72,11 @@ This release removes a lot of code that has since been released as part of WPGra
 In order to use v0.2.0+ of WPGraphQL Smart Cache, you will need WPGraphQL v1.12.0 or newer.
 
 == Changelog ==
+
+= 1.0.4 =
+
+- [#210](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/210) fix: post_exists being called even though the `post_exists` function doesn't exist in this context. Check instanceof WP_Post instead.
+
 
 = 1.0.3 =
 

--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -11,7 +11,7 @@
  * Requires PHP: 7.4
  * Text Domain: wp-graphql-smart-cache
  * Domain Path: /languages
- * Version: 1.0.3
+ * Version: 1.0.4
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -44,7 +44,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 if ( ! defined( 'WPGRAPHQL_SMART_CACHE_VERSION' ) ) {
-	define( 'WPGRAPHQL_SMART_CACHE_VERSION', '1.0.3' );
+	define( 'WPGRAPHQL_SMART_CACHE_VERSION', '1.0.4' );
 }
 
 if ( ! defined( 'WPGRAPHQL_SMART_CACHE_WPGRAPHQL_REQUIRED_MIN_VERSION' ) ) {


### PR DESCRIPTION
# Release Notes

## Chores / Bugfixes

- [#210](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/210) fix: fixes a regression to v1.0.3 where `post_exists()` was being called even though the `post_exists` function doesn't exist in this context. Instead this checks `instanceof WP_Post` instead.
