### PR TITLE
fix: #212 over purging tags

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -409,7 +409,6 @@ class Invalidation {
 		$type_name = strtolower( $tax_object->graphql_single_name );
 
 		$this->purge( 'list:' . $type_name );
-
 	}
 
 	/**
@@ -422,7 +421,6 @@ class Invalidation {
 	 * @return void
 	 */
 	public function on_deleted_term_relationship_cb( $object_id, $tt_id, $taxonomy ) {
-
 		if ( ! $this->is_taxonomy_tracked( $taxonomy ) ) {
 			return;
 		}
@@ -439,7 +437,6 @@ class Invalidation {
 		$this->purge_nodes( 'term', $term->term_id );
 		$type_name = strtolower( $tax_object->graphql_single_name );
 		$this->purge( 'list:' . $type_name );
-
 	}
 
 	/**
@@ -452,7 +449,6 @@ class Invalidation {
 	 * @return void
 	 */
 	public function on_added_term_relationship_cb( $object_id, $tt_id, $taxonomy ) {
-
 		if ( ! $this->is_taxonomy_tracked( $taxonomy ) ) {
 			return;
 		}
@@ -467,9 +463,8 @@ class Invalidation {
 		$this->purge_nodes( 'term', $term->term_id );
 
 		$tax_object = get_taxonomy( $term->taxonomy );
-		$type_name = strtolower( $tax_object->graphql_single_name );
+		$type_name  = strtolower( $tax_object->graphql_single_name );
 		$this->purge( 'list:' . $type_name );
-
 	}
 
 	/**
@@ -540,17 +535,19 @@ class Invalidation {
 		if ( 'CREATE' === $action_type ) {
 			$this->purge( 'list:' . $type_name );
 
-			$terms = wp_get_object_terms( $post->ID, \WPGraphQL::get_allowed_taxonomies()  );
+			$terms = wp_get_object_terms( $post->ID, \WPGraphQL::get_allowed_taxonomies() );
 
 			if ( ! empty( $terms ) ) {
-				array_map( function( $term ) use ( $post ) {
-					if ( ! $term instanceof WP_Term ) {
-						return;
-					}
-					$this->on_added_term_relationship_cb( $post->ID, $term->term_taxonomy_id, $term->taxonomy );
-				}, $terms );
+				array_map(
+					function ( $term ) use ( $post ) {
+						if ( ! $term instanceof WP_Term ) {
+							return;
+						}
+						$this->on_added_term_relationship_cb( $post->ID, $term->term_taxonomy_id, $term->taxonomy );
+					},
+					$terms
+				);
 			}
-
 		}
 
 		// if we update or delete a post
@@ -562,19 +559,20 @@ class Invalidation {
 		}
 
 		if ( 'DELETE' === $action_type ) {
-
-			$terms = wp_get_object_terms( $post->ID, \WPGraphQL::get_allowed_taxonomies()  );
+			$terms = wp_get_object_terms( $post->ID, \WPGraphQL::get_allowed_taxonomies() );
 
 			if ( ! empty( $terms ) ) {
-				array_map( function( $term ) use ( $post ) {
-					if ( ! $term instanceof WP_Term ) {
-						return;
-					}
-					$this->on_deleted_term_relationship_cb( $post->ID, $term->term_taxonomy_id, $term->taxonomy );
-				}, $terms );
+				array_map(
+					function ( $term ) use ( $post ) {
+						if ( ! $term instanceof WP_Term ) {
+							return;
+						}
+						$this->on_deleted_term_relationship_cb( $post->ID, $term->term_taxonomy_id, $term->taxonomy );
+					},
+					$terms
+				);
 			}
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
This PR changes the actions that are listened to for purging tags. 

Instead of purging in response to the `edited_term_taxonomy`, which gets called when a post associated with a term is updatated, even when the term relationship hasn't changed, this now responds to the `added_term_relationship` and `deleted_term_relationship` hooks, as well as the `saved_term` hook. 

In addition, this adds logic to the transition post status callback to also call the added/deleted term relationship callbacks. 