### PR TITLE
fix: updating menus not assigned to locations doesn't purge menus, even if their model is public

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -807,8 +807,6 @@ class Invalidation {
 	 */
 	public function on_create_nav_menu_cb( $menu_id, array $menu_data ) {
 		if ( ! $this->is_menu_public( $menu_id ) ) {
-			codecept_debug( 'created menu is not public' );
-			error_log( 'created menu is not public' );
 			return;
 		}
 

--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -499,7 +499,6 @@ class Invalidation {
 		$tax_object = get_taxonomy( $term->taxonomy );
 		$type_name  = strtolower( $tax_object->graphql_single_name );
 		$this->purge( 'list:' . $type_name, 'term_edited' );
-
 	}
 
 	/**


### PR DESCRIPTION
- Updates `is_menu_public` to determine whether a menu is public from the Model, instead of hard-coded logic about the locations

closes #220 

~(needs a test still)~