### PR TITLE
fix: update term action purge calls

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -496,7 +496,6 @@ class Invalidation {
 
 		// Delete the cached results associated with this post/key
 		$this->purge_nodes( 'term', $term->term_id, 'term_relationship_added' );
-
 	}
 
 	/**

--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -226,7 +226,7 @@ class Invalidation {
 	 * @param mixed|string|int $id The node entity identifier
 	 * @param string $event The event that caused the purge
 	 */
-	public function purge_nodes( $id_prefix, $id, $event = '' ) {
+	public function purge_nodes( $id_prefix, $id, $event = 'unknown event' ) {
 		if ( ! method_exists( Relay::class, 'toGlobalId' ) ) {
 			return;
 		}
@@ -439,7 +439,7 @@ class Invalidation {
 		$tax_object = get_taxonomy( $taxonomy );
 
 		// Delete the cached results associated with this post/key
-		$this->purge_nodes( 'term', $term->term_id );
+		$this->purge_nodes( 'term', $term->term_id, 'term_saved' );
 
 		$type_name = strtolower( $tax_object->graphql_single_name );
 
@@ -469,7 +469,7 @@ class Invalidation {
 		$tax_object = get_taxonomy( $taxonomy );
 
 		// Delete the cached results associated with this post/key
-		$this->purge_nodes( 'term', $term->term_id );
+		$this->purge_nodes( 'term', $term->term_id, 'term_relationship_deleted' );
 		$type_name = strtolower( $tax_object->graphql_single_name );
 		$this->purge( 'list:' . $type_name, 'term_relationship_deleted' );
 	}
@@ -495,11 +495,8 @@ class Invalidation {
 		}
 
 		// Delete the cached results associated with this post/key
-		$this->purge_nodes( 'term', $term->term_id, 'term_edited' );
+		$this->purge_nodes( 'term', $term->term_id, 'term_relationship_added' );
 
-		$tax_object = get_taxonomy( $term->taxonomy );
-		$type_name  = strtolower( $tax_object->graphql_single_name );
-		$this->purge( 'list:' . $type_name, 'term_edited' );
 	}
 
 	/**


### PR DESCRIPTION
This PR updates the purge events that are called in response to term updates. 

When a term is saved, this adds the previously missing event name "term_saved" and when a term is removed from being associated with an object, this adds the previously missing event name "term_relationship_deleted".

Additionally, when an object is associated with a term the callback no longer calls purge on `list:$taxonomy_name`