### PR TITLE
bug:Do not cache mutations to object cache results

### DIFF
--- a/src/Cache/Results.php
+++ b/src/Cache/Results.php
@@ -115,6 +115,11 @@ class Results extends Query {
 			return $result;
 		}
 
+		// For mutation, do not cache
+		if ( 'Mutation' === $request->get_query_analyzer()->get_root_operation() ) {
+			return;
+		}
+
 		// Loop over each request and load the response. If any one are empty, not in cache, return so all get reloaded.
 		if ( is_array( $request->params ) ) {
 			$result = [];
@@ -221,6 +226,11 @@ class Results extends Query {
 		//
 		// Possibly in the future we'll have solutions for authenticated request caching
 		if ( ! $this->is_object_cache_enabled() ) {
+			return;
+		}
+
+		// For mutation, do not cache
+		if ( 'Mutation' === $request->get_query_analyzer()->get_root_operation() ) {
 			return;
 		}
 

--- a/tests/wpunit/CacheResultsTest.php
+++ b/tests/wpunit/CacheResultsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace WPGraphQL\SmartCache;
+
+class CacheResultsTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Enable the local cache transient cache for these tests
+		add_option( 'graphql_cache_section', [ 'cache_toggle' => 'on' ] );
+
+        $this->user = self::factory()->user->create_and_get( [
+            'role' => 'administrator',
+        ] );
+	}
+
+	public function tearDown(): void {
+		delete_option( 'graphql_cache_section' );
+
+		parent::tearDown();
+	}
+
+	public function testMutationNotAuthenticatedDoesNotCacheResults() {
+		$post_id = self::factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			''
+		]);
+		codecept_debug( "POST $post_id\n");
+
+		// mutation to add comment to an existing post
+		$mutation = 'mutation MyComment($input: CreateCommentInput!) {
+			createComment(input: $input) {
+				comment {
+					id
+					commentedOn {
+						node {
+							__typename
+							id
+						}
+					}
+					content
+				}
+			}
+		}';
+
+		$variables = [
+			"input" => [
+				"commentOn" => $post_id,
+				"content" => "yoyo 4",
+				"author" => $this->user->user_login,
+				"authorEmail" => 'user@example.com'
+			],
+		];
+		codecept_debug( $variables );
+
+		$response = do_graphql_request( $mutation, 'MyComment', $variables );
+		codecept_debug( $response );
+		$this->assertEmpty( $response['extensions']['graphqlSmartCache']['graphqlObjectCache'] );
+
+		$response = do_graphql_request( $mutation, 'MyComment', $variables );
+		codecept_debug( $response );
+		$this->assertEmpty( $response['extensions']['graphqlSmartCache']['graphqlObjectCache'] );
+
+	}
+
+}


### PR DESCRIPTION
When smart cache object cache is enabled to store results of queries, do not get/store mutation requests.

Fixes https://github.com/wp-graphql/wp-graphql-smart-cache/issues/196

