### PR TITLE
Handle errors when editing queries in admin editor

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2451,16 +2451,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.16.0",
+            "version": "v4.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
                 "shasum": ""
             },
             "require": {
@@ -2501,9 +2501,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
             },
-            "time": "2023-06-25T14:52:30+00:00"
+            "time": "2023-08-13T19:53:39+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2618,21 +2618,21 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.2.1",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "0009429e639b748eef1c955200ea0d4e5ad5627d"
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/0009429e639b748eef1c955200ea0d4e5ad5627d",
-                "reference": "0009429e639b748eef1c955200ea0d4e5ad5627d",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
                 "shasum": ""
             },
             "require-dev": {
-                "nikic/php-parser": "< 4.12.0",
-                "php": "~7.3 || ~8.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ~8.0.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.3",
                 "phpstan/phpstan": "^1.10.12",
@@ -2640,7 +2640,6 @@
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
-                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
                 "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
             },
             "type": "library",
@@ -2657,9 +2656,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.2.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.3.0"
             },
-            "time": "2023-05-18T04:35:23+00:00"
+            "time": "2023-08-10T16:34:11+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
@@ -2947,16 +2946,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.28",
+            "version": "1.10.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e4545b55904ebef470423d3ddddb74fa7325497a"
+                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e4545b55904ebef470423d3ddddb74fa7325497a",
-                "reference": "e4545b55904ebef470423d3ddddb74fa7325497a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
+                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
                 "shasum": ""
             },
             "require": {
@@ -3005,7 +3004,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-08T12:33:42+00:00"
+            "time": "2023-08-14T13:24:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -155,16 +155,16 @@
         },
         {
             "name": "axepress/wp-graphql-stubs",
-            "version": "v1.14.9",
+            "version": "v1.14.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AxeWP/wp-graphql-stubs.git",
-                "reference": "1e8509bf6b901e3ee799c87f44cb87b7a6dcfb34"
+                "reference": "60601f1fe1798ba8168242320b36907f4fe2bb3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/1e8509bf6b901e3ee799c87f44cb87b7a6dcfb34",
-                "reference": "1e8509bf6b901e3ee799c87f44cb87b7a6dcfb34",
+                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/60601f1fe1798ba8168242320b36907f4fe2bb3b",
+                "reference": "60601f1fe1798ba8168242320b36907f4fe2bb3b",
                 "shasum": ""
             },
             "require": {
@@ -195,7 +195,7 @@
             ],
             "support": {
                 "issues": "https://github.com/AxeWP/wp-graphql-stubs/issues",
-                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.14.9"
+                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.14.10"
             },
             "funding": [
                 {
@@ -203,7 +203,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-07-28T01:18:30+00:00"
+            "time": "2023-08-04T12:31:37+00:00"
         },
         {
             "name": "behat/gherkin",
@@ -1445,16 +1445,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6"
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
-                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/111166291a0f8130081195ac4556a5587d7f1b5d",
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d",
                 "shasum": ""
             },
             "require": {
@@ -1508,7 +1508,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.0"
+                "source": "https://github.com/guzzle/promises/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1524,20 +1524,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T13:50:22+00:00"
+            "time": "2023-08-03T15:11:55+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
+                "reference": "8bd7c33a0734ae1c5d074360512beb716bef3f77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/8bd7c33a0734ae1c5d074360512beb716bef3f77",
+                "reference": "8bd7c33a0734ae1c5d074360512beb716bef3f77",
                 "shasum": ""
             },
             "require": {
@@ -1624,7 +1624,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.0"
             },
             "funding": [
                 {
@@ -1640,11 +1640,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:11:26+00:00"
+            "time": "2023-08-03T15:06:02+00:00"
         },
         {
             "name": "illuminate/collections",
-            "version": "v10.17.1",
+            "version": "v10.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1699,7 +1699,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.17.1",
+            "version": "v10.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1745,7 +1745,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.17.1",
+            "version": "v10.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1793,7 +1793,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.17.1",
+            "version": "v10.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1839,16 +1839,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v10.17.1",
+            "version": "v10.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "7549dd081cc45c742b7d97064b64cf67fab4c7b6"
+                "reference": "9ce4a26975a919ec33ed21307633ac02208537a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/7549dd081cc45c742b7d97064b64cf67fab4c7b6",
-                "reference": "7549dd081cc45c742b7d97064b64cf67fab4c7b6",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/9ce4a26975a919ec33ed21307633ac02208537a8",
+                "reference": "9ce4a26975a919ec33ed21307633ac02208537a8",
                 "shasum": ""
             },
             "require": {
@@ -1906,7 +1906,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-07-31T15:02:41+00:00"
+            "time": "2023-08-08T14:14:45+00:00"
         },
         {
             "name": "ivome/graphql-relay-php",
@@ -2947,16 +2947,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.26",
+            "version": "1.10.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "5d660cbb7e1b89253a47147ae44044f49832351f"
+                "reference": "e4545b55904ebef470423d3ddddb74fa7325497a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5d660cbb7e1b89253a47147ae44044f49832351f",
-                "reference": "5d660cbb7e1b89253a47147ae44044f49832351f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e4545b55904ebef470423d3ddddb74fa7325497a",
+                "reference": "e4545b55904ebef470423d3ddddb74fa7325497a",
                 "shasum": ""
             },
             "require": {
@@ -3005,7 +3005,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-19T12:44:37+00:00"
+            "time": "2023-08-08T12:33:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4753,16 +4753,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.16",
+            "version": "v2.11.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
                 "shasum": ""
             },
             "require": {
@@ -4807,7 +4807,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2023-03-31T16:46:32+00:00"
+            "time": "2023-08-05T23:46:11+00:00"
         },
         {
             "name": "softcreatr/jsonpath",
@@ -7042,16 +7042,16 @@
         },
         {
             "name": "wp-graphql/wp-graphql",
-            "version": "v1.14.9",
+            "version": "v1.14.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-graphql/wp-graphql.git",
-                "reference": "df0d10f867f3591060ef0e0b5d5e7264ae0a77d1"
+                "reference": "f70ac589c6a67892b3f1e3c8415f1d379f279bee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/df0d10f867f3591060ef0e0b5d5e7264ae0a77d1",
-                "reference": "df0d10f867f3591060ef0e0b5d5e7264ae0a77d1",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/f70ac589c6a67892b3f1e3c8415f1d379f279bee",
+                "reference": "f70ac589c6a67892b3f1e3c8415f1d379f279bee",
                 "shasum": ""
             },
             "require": {
@@ -7116,9 +7116,9 @@
             "description": "GraphQL API for WordPress",
             "support": {
                 "issues": "https://github.com/wp-graphql/wp-graphql/issues",
-                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.14.9"
+                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.14.10"
             },
-            "time": "2023-07-26T22:00:34+00:00"
+            "time": "2023-08-03T22:09:10+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -72,6 +72,9 @@ class Editor {
 
 				} else {
 					$data['post_status'] = 'draft';
+					
+					// This prevents the Admin UI from showing that the post has previously been published (because it actually hasn't been)
+					$data['post_date_gmt'] = '0000-00-00 00:00:00';
 				}
 			}
 		}

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -90,13 +90,13 @@ class Editor {
 
 				} else {
 					$data['post_status'] = 'draft';
-					
+
 					// This prevents the Admin UI from showing that the post has previously been published (because it actually hasn't been)
-					if ( isset( $existing_post['post_date'] ) ) {
+					if ( isset( $existing_post['post_date'] ) && isset( $existing_post['post_date_gmt'] ) && '0000-00-00 00:00:00' !== $existing_post['post_date_gmt'] ) {
 						$data['post_date']     = $existing_post['post_date'];
 						$data['post_date_gmt'] = get_gmt_from_date( $existing_post['post_date'] );
 					} else {
-						$data['post_date']     = '0000-00-00 00:00:00';
+						// Clearing this is same as removing the publish date.
 						$data['post_date_gmt'] = '0000-00-00 00:00:00';
 					}
 				}

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -62,10 +62,14 @@ class Editor {
 
 			// If encountered invalid data when publishing query, revert some data. If draft, allow invalid query.
 			if ( 'publish' === $post['post_status'] ) {
-				// If has an existing post and is published, revert post content to that previous value.
+
+				// If has an existing published post and trying to publish with errors, bail before save_post
 				$existing_post = get_post( $post['ID'], ARRAY_A );
 				if ( $existing_post && 'publish' === $existing_post['post_status'] ) {
-					$data['post_content'] = $existing_post['post_content'];
+
+					wp_safe_redirect( admin_url( sprintf( '/post.php?post=%d&action=edit', $post['ID'] ) ) );
+					exit;
+
 				} else {
 					$data['post_status'] = 'draft';
 				}

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -74,7 +74,13 @@ class Editor {
 					$data['post_status'] = 'draft';
 					
 					// This prevents the Admin UI from showing that the post has previously been published (because it actually hasn't been)
-					$data['post_date_gmt'] = '0000-00-00 00:00:00';
+					if ( isset( $existing_post['post_date'] ) ) {
+						$data['post_date']     = $existing_post['post_date'];
+						$data['post_date_gmt'] = get_gmt_from_date( $existing_post['post_date'] );
+					} else {
+						$data['post_date']     = '0000-00-00 00:00:00';
+						$data['post_date_gmt'] = '0000-00-00 00:00:00';
+					}
 				}
 			}
 		}

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -45,8 +45,14 @@ class Editor {
 	 */
 	public function untrashed_post_cb( $post_id, $previous_status ) {
 		// If have errors when validating the post content/data, do not show those in the admin when untrash.
+		$untrashed_post = get_post( $post_id );
+		
+		// Bail if the untrashed post is not a GraphQL Document
+		if ( ! isset( $untrashed_post->post_type ) || Document::TYPE_NAME !== $untrashed_post->post_type ) {
+			return;
+		}
+	
 		delete_transient( AdminErrors::TRANSIENT_NAME );
-
 	}
 
 	/**

--- a/src/AdminErrors.php
+++ b/src/AdminErrors.php
@@ -19,6 +19,7 @@ class AdminErrors {
 	 */
 	public function init() {
 		add_action( 'admin_notices', [ $this, 'display_validation_messages' ] );
+		add_filter( 'post_updated_messages', [ $this, 'post_updated_messages_cb' ] );
 	}
 
 	/**
@@ -62,5 +63,23 @@ class AdminErrors {
 		}
 
 		delete_transient( self::TRANSIENT_NAME );
+	}
+
+	/**
+	* Filters the post updated messages.
+	*
+	* @param array[] $messages Post updated messages.
+	* @return array[]
+	*/
+	public function post_updated_messages_cb( $messages ) {
+		// If have admin error message, don't display the 'Post Published' message for this post type
+		$error_messages = get_transient( self::TRANSIENT_NAME );
+		if ( ! empty( $error_messages ) ) {
+			// phpcs:ignore
+			$message_number                                     = isset( $_GET['message'] ) ? absint( $_GET['message'] ) : 0;
+			$messages[ Document::TYPE_NAME ][ $message_number ] = '';
+		}
+
+		return $messages;
 	}
 }

--- a/tests/acceptance/QueryIdCest.php
+++ b/tests/acceptance/QueryIdCest.php
@@ -2,42 +2,56 @@
 
 class QueryIdCest
 {
-    public function queryIdThatDoesNotExistTest(AcceptanceTester $I)
-    {
-        $I->sendGet('graphql', [ 'queryId' => '1234' ] );
-        $I->seeResponseContainsJson([
-            'errors' => [
-                'message' => 'PersistedQueryNotFound'
-            ]
-        ]);
-    }
- 
-    public function saveQueryAndHashTest(AcceptanceTester $I)
-    {
-        $I->sendPost('graphql', [
-            'query' => '{__typename}',
-            'queryId' => '8d8f7365e9e86fa8e3313fcaf2131b801eafe9549de22373089cf27511858b39'
-        ] );
-        $I->seeResponseContainsJson([
-           'data' => [
-               '__typename' => 'RootQuery'
-           ]
-        ]);
+	public function queryIdThatDoesNotExistTest(AcceptanceTester $I)
+	{
+		$I->sendGet('graphql', [ 'queryId' => '1234' ] );
+		$I->seeResponseContainsJson([
+			'errors' => [
+				'message' => 'PersistedQueryNotFound'
+			]
+		]);
+	}
 
-        $I->sendPost('graphql', [
-            'query' => '{ __typename }',
-            'extensions' => [
-                "persistedQuery" => [
-                    "version" => 1,
-                    "sha256Hash" => "8d8f7365e9e86fa8e3313fcaf2131b801eafe9549de22373089cf27511858b39"
-                ]
-            ]
-        ] );
-        $I->seeResponseContainsJson([
-            'data' => [
-                '__typename' => 'RootQuery'
-            ]
-        ]);
-    }
+	// If send empty string and a query id that does not exist, will get not found error
+	public function sendEmptyQueryStringWithQueryIdIsErrorTest(AcceptanceTester $I)
+	{
+		$I->sendPost('graphql', [
+			'query' => '',
+			'queryId' => 'alias-does-not-exist'
+		] );
+		$I->seeResponseContainsJson([
+			'errors' => [
+				'message' => 'PersistedQueryNotFound'
+			]
+		]);
+	}
+
+	public function saveQueryAndHashTest(AcceptanceTester $I)
+	{
+		$I->sendPost('graphql', [
+			'query' => '{__typename}',
+			'queryId' => '8d8f7365e9e86fa8e3313fcaf2131b801eafe9549de22373089cf27511858b39'
+		] );
+		$I->seeResponseContainsJson([
+		   'data' => [
+			   '__typename' => 'RootQuery'
+		   ]
+		]);
+
+		$I->sendPost('graphql', [
+			'query' => '{ __typename }',
+			'extensions' => [
+				"persistedQuery" => [
+					"version" => 1,
+					"sha256Hash" => "8d8f7365e9e86fa8e3313fcaf2131b801eafe9549de22373089cf27511858b39"
+				]
+			]
+		] );
+		$I->seeResponseContainsJson([
+			'data' => [
+				'__typename' => 'RootQuery'
+			]
+		]);
+	}
  
 }

--- a/tests/functional/AdminEditorDocumentCest.php
+++ b/tests/functional/AdminEditorDocumentCest.php
@@ -115,9 +115,9 @@ class AdminEditorDocumentCest {
 			'post_content' => $normalized_query_string,
 		]);
 
-
 		$I->seeElement('//*[@id="message"]');
 		$I->see('Post draft updated.', '//*[@id="message"]');
+		$I->see('Publish immediately'); // does not have a publish date
 	}
 
 	public function createNewQueryWithEmptyContentWhenSaveDraftSavesAsDraftTest( FunctionalTester $I ) {
@@ -143,6 +143,7 @@ class AdminEditorDocumentCest {
 
 		$I->seeElement('//*[@id="message"]');
 		$I->see('Post draft updated.', '//*[@id="message"]');
+		$I->see('Publish immediately'); // does not have a publish date
 	}
 
 	public function createNewQueryWithEmptyContentWhenPublishSavesAsDraftTest( FunctionalTester $I ) {
@@ -171,6 +172,7 @@ class AdminEditorDocumentCest {
 		$I->dontSeeElement('//*[@id="message"]');
 		$I->dontSee('Post draft updated.');
 		$I->dontSee('Post published.');
+		$I->see('Publish immediately'); // does not have a publish date
 	}
 
 	public function createNewQueryWithInvalidContentWhenPublishSavesAsDraftTest( FunctionalTester $I ) {
@@ -199,6 +201,7 @@ class AdminEditorDocumentCest {
 		$I->dontSeeElement('//*[@id="message"]');
 		$I->dontSee('Post draft updated.');
 		$I->dontSee('Post published.');
+		$I->see('Publish immediately'); // does not have publish date
 	}
 
 	public function createNewQueryWithoutErrorWhenPublishSavesAsPublishedTest( FunctionalTester $I ) {
@@ -227,6 +230,7 @@ class AdminEditorDocumentCest {
 
 		$I->seeElement('//*[@id="message"]');
 		$I->see('Post published.', '//*[@id="message"]');
+		$I->dontSee('Publish immediately'); // has publish date
 	}
 
 	public function haveDraftQueryWithInvalidQueryWhenPublishSavesAsDraftTest( FunctionalTester $I ) {
@@ -265,6 +269,7 @@ class AdminEditorDocumentCest {
 		$I->dontSeeElement('//*[@id="message"]');
 		$I->dontSee('Post draft updated.');
 		$I->dontSee('Post published.');
+		$I->see('Publish immediately'); // does not have publish date
 	}
 
 	public function haveDraftQueryWithValidQueryWhenPublishSavesAsPublishedTest( FunctionalTester $I ) {
@@ -302,6 +307,7 @@ class AdminEditorDocumentCest {
 
 		$I->seeElement('//*[@id="message"]');
 		$I->see('Post published.', '//*[@id="message"]');
+		$I->dontSee('Publish immediately'); // has publish date
 	}
 
 	public function havePublishedQueryWhenSaveDraftWithInvalidQuerySavesAsDraftTest( FunctionalTester $I ) {
@@ -344,6 +350,7 @@ class AdminEditorDocumentCest {
 		$I->dontSee('Post published.');
 		$I->dontSee('Post updated.');
 		$I->dontSee('Post saved.');
+		$I->dontSee('Publish immediately'); // has date because already published
 	}
 
 	public function havePublishedQueryWhenSaveDraftWithValidQuerySavesAsDraftTest( FunctionalTester $I ) {
@@ -384,6 +391,7 @@ class AdminEditorDocumentCest {
 
 		$I->seeElement('//*[@id="message"]');
 		$I->see('Post draft updated.', '//*[@id="message"]');
+		$I->dontSee('Publish immediately'); // has date because already published
 	}
 
 	public function havePublishedQueryWithInvalidQueryWhenPublishItShowsPreviousQueryContentTest( FunctionalTester $I ) {
@@ -426,6 +434,7 @@ class AdminEditorDocumentCest {
 		$I->dontSee('Post published.');
 		$I->dontSee('Post updated.');
 		$I->dontSee('Post saved.');
+		$I->dontSee('Publish immediately'); // has date because already published
 	}
 
 	public function createNewQueryWithInvalidContentThenTrashItTest( FunctionalTester $I ) {

--- a/tests/functional/AdminEditorDocumentCest.php
+++ b/tests/functional/AdminEditorDocumentCest.php
@@ -114,6 +114,10 @@ class AdminEditorDocumentCest {
 			'post_status' => 'draft',
 			'post_content' => $normalized_query_string,
 		]);
+
+
+		$I->seeElement('//*[@id="message"]');
+		$I->see('Post draft updated.', '//*[@id="message"]');
 	}
 
 	public function createNewQueryWithEmptyContentWhenSaveDraftSavesAsDraftTest( FunctionalTester $I ) {
@@ -136,6 +140,9 @@ class AdminEditorDocumentCest {
 			'post_status' => 'draft',
 			'post_content' => '',
 		]);
+
+		$I->seeElement('//*[@id="message"]');
+		$I->see('Post draft updated.', '//*[@id="message"]');
 	}
 
 	public function createNewQueryWithEmptyContentWhenPublishSavesAsDraftTest( FunctionalTester $I ) {
@@ -160,6 +167,10 @@ class AdminEditorDocumentCest {
 			'post_status' => 'draft',
 			'post_content' => '',
 		]);
+
+		$I->dontSeeElement('//*[@id="message"]');
+		$I->dontSee('Post draft updated.');
+		$I->dontSee('Post published.');
 	}
 
 	public function createNewQueryWithInvalidContentWhenPublishSavesAsDraftTest( FunctionalTester $I ) {
@@ -184,6 +195,10 @@ class AdminEditorDocumentCest {
 			'post_status' => 'draft',
 			'post_content' => '{ __typename broken',
 		]);
+
+		$I->dontSeeElement('//*[@id="message"]');
+		$I->dontSee('Post draft updated.');
+		$I->dontSee('Post published.');
 	}
 
 	public function createNewQueryWithoutErrorWhenPublishSavesAsPublishedTest( FunctionalTester $I ) {
@@ -209,6 +224,9 @@ class AdminEditorDocumentCest {
 			'post_status' => 'publish',
 			'post_content' => $normalized_query_string,
 		]);
+
+		$I->seeElement('//*[@id="message"]');
+		$I->see('Post published.', '//*[@id="message"]');
 	}
 
 	public function haveDraftQueryWithInvalidQueryWhenPublishSavesAsDraftTest( FunctionalTester $I ) {
@@ -243,6 +261,10 @@ class AdminEditorDocumentCest {
 			'post_status' => 'draft',
 			'post_content' => '{ __typename broken',
 		]);
+
+		$I->dontSeeElement('//*[@id="message"]');
+		$I->dontSee('Post draft updated.');
+		$I->dontSee('Post published.');
 	}
 
 	public function haveDraftQueryWithValidQueryWhenPublishSavesAsPublishedTest( FunctionalTester $I ) {
@@ -277,6 +299,9 @@ class AdminEditorDocumentCest {
 			'post_status' => 'publish',
 			'post_content' => "{\n  posts {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n}\n",
 		]);
+
+		$I->seeElement('//*[@id="message"]');
+		$I->see('Post published.', '//*[@id="message"]');
 	}
 
 	public function havePublishedQueryWhenSaveDraftWithInvalidQuerySavesAsDraftTest( FunctionalTester $I ) {
@@ -314,6 +339,11 @@ class AdminEditorDocumentCest {
 			'post_status' => 'draft',
 			'post_content' => '{ __typename broken',
 		]);
+
+		$I->dontSeeElement('//*[@id="message"]');
+		$I->dontSee('Post published.');
+		$I->dontSee('Post updated.');
+		$I->dontSee('Post saved.');
 	}
 
 	public function havePublishedQueryWhenSaveDraftWithValidQuerySavesAsDraftTest( FunctionalTester $I ) {
@@ -351,6 +381,9 @@ class AdminEditorDocumentCest {
 			'post_status' => 'draft',
 			'post_content' => "{\n  posts {\n    edges {\n      node {\n        id\n      }\n    }\n  }\n}\n",
 		]);
+
+		$I->seeElement('//*[@id="message"]');
+		$I->see('Post draft updated.', '//*[@id="message"]');
 	}
 
 	public function havePublishedQueryWithInvalidQueryWhenPublishItShowsPreviousQueryContentTest( FunctionalTester $I ) {
@@ -388,5 +421,10 @@ class AdminEditorDocumentCest {
 			'post_status' => 'publish',
 			'post_content' => $normalized_query_string,
 		]);
+
+		$I->dontSeeElement('//*[@id="message"]');
+		$I->dontSee('Post published.');
+		$I->dontSee('Post updated.');
+		$I->dontSee('Post saved.');
 	}
 }

--- a/tests/functional/AdminSettingsCacheCest.php
+++ b/tests/functional/AdminSettingsCacheCest.php
@@ -11,17 +11,17 @@ class AdminSettingsCacheCest
 	}
 
 	public function selectCacheSettingsTest( FunctionalTester $I ) {
-			$I->loginAsAdmin();
-			$I->amOnPage('/wp-admin/admin.php?page=graphql-settings#graphql_cache_section');
+		$I->loginAsAdmin();
+		$I->amOnPage('/wp-admin/admin.php?page=graphql-settings#graphql_cache_section');
 
-			// Save and see the selection after form submit
-			$I->checkOption("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
-			$I->click('Save Changes');
-			$I->seeCheckboxIsChecked("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
+		// Save and see the selection after form submit
+		$I->checkOption("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
+		$I->click('Save Changes');
+		$I->seeCheckboxIsChecked("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
 
-			$I->uncheckOption("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
-			$I->click('Save Changes');
-			$I->dontSeeCheckboxIsChecked("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
+		$I->uncheckOption("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
+		$I->click('Save Changes');
+		$I->dontSeeCheckboxIsChecked("//input[@type='checkbox' and @name='graphql_cache_section[cache_toggle]']");
 	}
 
 	public function saveCacheTllExpirationTest( FunctionalTester $I ) {


### PR DESCRIPTION
When editing saved persisted queries in WP admin editor, do not allow invalid queries to be published.  But allow invalid queries to be saved as drafts.

closes #243 