### PR TITLE
feature: Add variable validation rule to query save

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1645,16 +1645,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "66ff5aab0dd10659aff0efe3ff101819db192dfe"
+                "reference": "f494398dbaaead9e5ff16a18002d11634e8358e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/66ff5aab0dd10659aff0efe3ff101819db192dfe",
-                "reference": "66ff5aab0dd10659aff0efe3ff101819db192dfe",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/f494398dbaaead9e5ff16a18002d11634e8358e6",
+                "reference": "f494398dbaaead9e5ff16a18002d11634e8358e6",
                 "shasum": ""
             },
             "require": {
@@ -1696,11 +1696,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-08-02T14:57:32+00:00"
+            "time": "2023-08-11T14:48:51+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1746,7 +1746,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1794,7 +1794,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1840,16 +1840,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "9ce4a26975a919ec33ed21307633ac02208537a8"
+                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/9ce4a26975a919ec33ed21307633ac02208537a8",
-                "reference": "9ce4a26975a919ec33ed21307633ac02208537a8",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
+                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
                 "shasum": ""
             },
             "require": {
@@ -1907,7 +1907,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-08-08T14:14:45+00:00"
+            "time": "2023-08-14T21:56:59+00:00"
         },
         {
             "name": "ivome/graphql-relay-php",
@@ -2350,24 +2350,28 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.68.1",
+            "version": "2.69.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "4f991ed2a403c85efbc4f23eb4030063fdbe01da"
+                "reference": "4308217830e4ca445583a37d1bf4aff4153fa81c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4f991ed2a403c85efbc4f23eb4030063fdbe01da",
-                "reference": "4f991ed2a403c85efbc4f23eb4030063fdbe01da",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4308217830e4ca445583a37d1bf4aff4153fa81c",
+                "reference": "4308217830e4ca445583a37d1bf4aff4153fa81c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
+                "psr/clock": "^1.0",
                 "symfony/polyfill-mbstring": "^1.0",
                 "symfony/polyfill-php80": "^1.16",
                 "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
             },
             "require-dev": {
                 "doctrine/dbal": "^2.0 || ^3.1.4",
@@ -2448,7 +2452,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-20T18:29:04+00:00"
+            "time": "2023-08-03T09:00:52+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3428,6 +3432,54 @@
                 }
             ],
             "time": "2023-07-10T04:04:23+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -1645,7 +1645,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1700,7 +1700,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1746,7 +1746,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1794,7 +1794,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1840,16 +1840,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f"
+                "reference": "38d3e064b7b9420d2173f23a31a435bde221b56d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
-                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/38d3e064b7b9420d2173f23a31a435bde221b56d",
+                "reference": "38d3e064b7b9420d2173f23a31a435bde221b56d",
                 "shasum": ""
             },
             "require": {
@@ -1907,7 +1907,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-08-14T21:56:59+00:00"
+            "time": "2023-08-21T13:45:59+00:00"
         },
         {
             "name": "ivome/graphql-relay-php",
@@ -2951,16 +2951,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.29",
+            "version": "1.10.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1"
+                "reference": "2910afdd3fe33e5afd71c09f3fb0d0845b48c410"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
-                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2910afdd3fe33e5afd71c09f3fb0d0845b48c410",
+                "reference": "2910afdd3fe33e5afd71c09f3fb0d0845b48c410",
                 "shasum": ""
             },
             "require": {
@@ -3009,7 +3009,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-14T13:24:11+00:00"
+            "time": "2023-08-22T13:48:25+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3432,54 +3432,6 @@
                 }
             ],
             "time": "2023-08-19T07:10:56+00:00"
-        },
-        {
-            "name": "psr/clock",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/clock.git",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Clock\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for reading the clock.",
-            "homepage": "https://github.com/php-fig/clock",
-            "keywords": [
-                "clock",
-                "now",
-                "psr",
-                "psr-20",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/clock/issues",
-                "source": "https://github.com/php-fig/clock/tree/1.0.0"
-            },
-            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/clock",
@@ -6841,16 +6793,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v14.11.9",
+            "version": "v14.11.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "ff91c9f3cf241db702e30b2c42bcc0920e70ac70"
+                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/ff91c9f3cf241db702e30b2c42bcc0920e70ac70",
-                "reference": "ff91c9f3cf241db702e30b2c42bcc0920e70ac70",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/d9c2fdebc6aa01d831bc2969da00e8588cffef19",
+                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19",
                 "shasum": ""
             },
             "require": {
@@ -6870,8 +6822,7 @@
                 "phpunit/phpunit": "^7.2 || ^8.5",
                 "psr/http-message": "^1.0",
                 "react/promise": "2.*",
-                "simpod/php-coveralls-mirror": "^3.0",
-                "squizlabs/php_codesniffer": "3.5.4"
+                "simpod/php-coveralls-mirror": "^3.0"
             },
             "suggest": {
                 "psr/http-message": "To use standard GraphQL server",
@@ -6895,7 +6846,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.9"
+                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.10"
             },
             "funding": [
                 {
@@ -6903,7 +6854,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-01-06T12:12:50+00:00"
+            "time": "2023-07-05T14:23:37+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -7142,23 +7093,23 @@
         },
         {
             "name": "wp-graphql/wp-graphql",
-            "version": "v1.14.10",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-graphql/wp-graphql.git",
-                "reference": "f70ac589c6a67892b3f1e3c8415f1d379f279bee"
+                "reference": "45a2e9e188fa5b2c6470efb9e53fac3691bbb610"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/f70ac589c6a67892b3f1e3c8415f1d379f279bee",
-                "reference": "f70ac589c6a67892b3f1e3c8415f1d379f279bee",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/45a2e9e188fa5b2c6470efb9e53fac3691bbb610",
+                "reference": "45a2e9e188fa5b2c6470efb9e53fac3691bbb610",
                 "shasum": ""
             },
             "require": {
                 "appsero/client": "1.2.1",
                 "ivome/graphql-relay-php": "0.6.0",
                 "php": "^7.1 || ^8.0",
-                "webonyx/graphql-php": "14.11.9"
+                "webonyx/graphql-php": "14.11.10"
             },
             "require-dev": {
                 "automattic/vipwpcs": "^2.2",
@@ -7216,9 +7167,9 @@
             "description": "GraphQL API for WordPress",
             "support": {
                 "issues": "https://github.com/wp-graphql/wp-graphql/issues",
-                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.14.10"
+                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.15.0"
             },
-            "time": "2023-08-03T22:09:10+00:00"
+            "time": "2023-08-23T05:42:30+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",

--- a/composer.lock
+++ b/composer.lock
@@ -104,28 +104,28 @@
         },
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.3",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
+                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
-                "squizlabs/php_codesniffer": "^3.5.5",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
+                "squizlabs/php_codesniffer": "^3.7.1",
                 "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
@@ -145,6 +145,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -152,7 +153,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2021-09-29T16:20:23+00:00"
+            "time": "2023-08-24T15:11:13+00:00"
         },
         {
             "name": "axepress/wp-graphql-stubs",
@@ -1041,35 +1042,38 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
+                "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1085,7 +1089,7 @@
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -1109,10 +1113,10 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "time": "2023-01-05T11:28:13+00:00"
         },
         {
             "name": "dg/mysql-dump",
@@ -2951,16 +2955,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.30",
+            "version": "1.10.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "2910afdd3fe33e5afd71c09f3fb0d0845b48c410"
+                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2910afdd3fe33e5afd71c09f3fb0d0845b48c410",
-                "reference": "2910afdd3fe33e5afd71c09f3fb0d0845b48c410",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
+                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
                 "shasum": ""
             },
             "require": {
@@ -3009,7 +3013,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-22T13:48:25+00:00"
+            "time": "2023-08-24T21:54:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -46,12 +46,12 @@ class Editor {
 	public function untrashed_post_cb( $post_id, $previous_status ) {
 		// If have errors when validating the post content/data, do not show those in the admin when untrash.
 		$untrashed_post = get_post( $post_id );
-		
+
 		// Bail if the untrashed post is not a GraphQL Document
 		if ( ! isset( $untrashed_post->post_type ) || Document::TYPE_NAME !== $untrashed_post->post_type ) {
 			return;
 		}
-	
+
 		delete_transient( AdminErrors::TRANSIENT_NAME );
 	}
 

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -12,6 +12,7 @@ use WPGraphQL\SmartCache\Document;
 use WPGraphQL\SmartCache\Document\Grant;
 use WPGraphQL\SmartCache\Document\MaxAge;
 use GraphQL\Error\SyntaxError;
+use GraphQL\Error\InvariantViolation;
 use GraphQL\Server\RequestError;
 
 class Editor {
@@ -81,7 +82,7 @@ class Editor {
 
 			$data['post_content'] = $document->valid_or_throw( $post['post_content'], $post['ID'] );
 
-		} catch ( RequestError $e ) {
+		} catch ( RequestError | InvariantViolation $e ) {
 			AdminErrors::add_message( $e->getMessage() );
 
 			// If encountered invalid data when publishing query, revert some data. If draft, allow invalid query.

--- a/src/ValidationRules/ArgShouldBeVariable.php
+++ b/src/ValidationRules/ArgShouldBeVariable.php
@@ -30,7 +30,7 @@ class ArgShouldBeVariable extends ValidationRule {
 					// Arguments in operation are process here, ex.  post( id: "1", idType: DATABASE_ID )
 
 					// If this argument should map to a variable
-					if ( 'StringValue' === $node->value->kind && 'Variable' !== $node->value->kind ) {
+					if ( 'StringValue' === $node->value->kind ) {
 						$context->reportError(new Error(
 							self::shouldBeVariableMessage( $node->name->value ),
 							$node

--- a/src/ValidationRules/ArgShouldBeVariable.php
+++ b/src/ValidationRules/ArgShouldBeVariable.php
@@ -31,7 +31,7 @@ class ArgShouldBeVariable extends ValidationRule {
 
 					// If this argument should map to a variable
 					// For a string or "idType" enum
-					if ( in_array( $node->value->kind, [ 'StringValue', 'EnumValue' ], true ) ) {
+					if ( in_array( $node->value->kind, [ 'StringValue', 'EnumValue', 'IntValue' ], true ) ) {
 						$context->reportError(new Error(
 							self::shouldBeVariableMessage( $node->name->value ),
 							$node
@@ -47,6 +47,6 @@ class ArgShouldBeVariable extends ValidationRule {
 	 * @return string
 	 */
 	public static function shouldBeVariableMessage( $varName ) {
-		return sprintf( __( 'Argument "$%s" should be a variable.', 'wp-graphql-smart-cache' ), $varName );
+		return sprintf( __( 'Argument "%s" should be a variable.', 'wp-graphql-smart-cache' ), $varName );
 	}
 }

--- a/src/ValidationRules/ArgShouldBeVariable.php
+++ b/src/ValidationRules/ArgShouldBeVariable.php
@@ -30,7 +30,8 @@ class ArgShouldBeVariable extends ValidationRule {
 					// Arguments in operation are process here, ex.  post( id: "1", idType: DATABASE_ID )
 
 					// If this argument should map to a variable
-					if ( 'StringValue' === $node->value->kind ) {
+					// For a string or "idType" enum
+					if ( in_array( $node->value->kind, [ 'StringValue', 'EnumValue' ], true ) ) {
 						$context->reportError(new Error(
 							self::shouldBeVariableMessage( $node->name->value ),
 							$node

--- a/src/ValidationRules/ArgShouldBeVariable.php
+++ b/src/ValidationRules/ArgShouldBeVariable.php
@@ -29,7 +29,7 @@ class ArgShouldBeVariable extends ValidationRule {
 			NodeKind::OBJECT_FIELD => [
 				'enter' => function ( ObjectFieldNode $node ) use ( $context ) {
 					// if object field node->value->kind is 'Variable' that's good.
-					// where clause objects
+					// where clause objects.  posts(where: {title: "hello"}) { .... }
 					if ( 'Variable' !== $node->value->kind ) {
 						$context->reportError(new Error(
 							self::shouldBeVariableMessage( $node->name->value ),
@@ -44,7 +44,7 @@ class ArgShouldBeVariable extends ValidationRule {
 					// Look for inputs; ie scalars, enums or more complex Input Object Types
 					// where clause has object values 'ObjectValue' === $node->value->kind
 
-					if ( 'Variable' !== $node->value->kind ) {
+					if ( 'ObjectValue' !== $node->value->kind && 'Variable' !== $node->value->kind ) {
 						$context->reportError(new Error(
 							self::shouldBeVariableMessage( $node->name->value ),
 							$node

--- a/src/ValidationRules/ArgShouldBeVariable.php
+++ b/src/ValidationRules/ArgShouldBeVariable.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace WPGraphQL\SmartCache\ValidationRules;
+
+use GraphQL\Error\Error;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\ArgumentNode;
+use GraphQL\Validator\Rules\ValidationRule;
+use GraphQL\Validator\ValidationContext;
+
+/**
+ * Class ArgShouldBeVariable
+ *
+ * @package WPGraphQL\SmartCache\Rules
+ */
+class ArgShouldBeVariable extends ValidationRule {
+
+	/**
+	 * Returns structure suitable for GraphQL\Language\Visitor
+	 *
+	 * @see \GraphQL\Language\Visitor
+	 *
+	 * @return mixed[]
+	 */
+	public function getVisitor( ValidationContext $context ) {
+
+		return [
+			NodeKind::ARGUMENT => [
+				'enter' => function ( ArgumentNode $node ) use ( $context ) {
+					// Arguments in operation are process here, ex.  post( id: "1", idType: DATABASE_ID )
+
+					// If this argument should map to a variable
+					if ( 'StringValue' === $node->value->kind && 'Variable' !== $node->value->kind ) {
+						$context->reportError(new Error(
+							self::shouldBeVariableMessage( $node->name->value ),
+							$node
+						));
+					}
+				},
+			],
+		];
+	}
+
+	/**
+	 * @param string $varName
+	 * @return string
+	 */
+	public static function shouldBeVariableMessage( $varName ) {
+		return sprintf( __( 'Argument "$%s" should be a variable.', 'wp-graphql-smart-cache' ), $varName );
+	}
+}

--- a/tests/_support/TestCase/WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches.php
+++ b/tests/_support/TestCase/WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches.php
@@ -542,14 +542,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singlePost' => [
 				'name' => 'singlePost',
 				'query' => '
-					query GetPost($id:ID!) {
-					  post(id:$id idType: DATABASE_ID) {
+					query GetPost($id:ID!, $id_type:PostIdType!) {
+					  post(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->published_post->ID ],
+				'variables' => [ 'id' => $this->published_post->ID, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'post.__typename', 'Post' ),
 					$this->expectedField( 'post.databaseId', $this->published_post->ID )
@@ -561,14 +561,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singlePostByEditor' => [
 				'name' => 'singlePostByEditor',
 				'query' => '
-					query GetPost($id:ID!) {
-					  post(id:$id idType: DATABASE_ID) {
+					query GetPost($id:ID!, $id_type:PostIdType!) {
+					  post(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->published_post_by_editor->ID ],
+				'variables' => [ 'id' => $this->published_post_by_editor->ID, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'post.__typename', 'Post' ),
 					$this->expectedField( 'post.databaseId', $this->published_post_by_editor->ID )
@@ -603,14 +603,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singlePage' => [
 				'name' => 'singlePage',
 				'query' => '
-					query GetPage($id:ID!) {
-					  page(id:$id idType: DATABASE_ID) {
+					query GetPage($id:ID!, $id_type:PageIdType!) {
+					  page(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->published_page->ID ],
+				'variables' => [ 'id' => $this->published_page->ID, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'page.__typename', 'Page' ),
 					$this->expectedField( 'page.databaseId', $this->published_page->ID )
@@ -645,14 +645,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singleTestPostType' => [
 				'name' => 'singleTestPostType',
 				'query' => '
-					query GetTestPostType($id:ID!) {
-					  testPostType(id:$id idType: DATABASE_ID) {
+					query GetTestPostType($id:ID!, $id_type:TestPostTypeIdType!) {
+					  testPostType(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->published_test_post_type->ID ],
+				'variables' => [ 'id' => $this->published_test_post_type->ID, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'testPostType.__typename', 'TestPostType' ),
 					$this->expectedField( 'testPostType.databaseId', $this->published_test_post_type->ID )
@@ -687,14 +687,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singlePrivatePostType' => [
 				'name' => 'singlePrivatePostType',
 				'query' => '
-					query GetPrivatePostType($id:ID!) {
-					  privatePostType(id:$id idType: DATABASE_ID) {
+					query GetPrivatePostType($id:ID!, $id_type:PrivatePostTypeIdType!) {
+					  privatePostType(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->published_private_post_type->ID ],
+				'variables' => [ 'id' => $this->published_private_post_type->ID, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					// since it's a private post type, the data should be null
 					$this->expectedField( 'privatePostType', self::IS_NULL ),
@@ -704,8 +704,8 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singleContentNode' => [
 				'name' => 'singleContentNode',
 				'query' => '
-					query GetContentNode($id:ID!) {
-					  contentNode(id:$id idType: DATABASE_ID) {
+					query GetContentNode($id:ID!, $id_type:ContentNodeIdTypeEnum!) {
+					  contentNode(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
@@ -713,6 +713,7 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 				',
 				'variables' => [
 					'id' => $this->published_post->ID,
+					'id_type' => 'DATABASE_ID',
 				],
 				'assertions' => [
 					$this->expectedField( 'contentNode.__typename', 'Post' ),
@@ -821,14 +822,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singleTag' => [
 				'name' => 'singleTag',
 				'query' => '
-					query GetTag($id:ID!) {
-					  tag(id:$id idType: DATABASE_ID) {
+					query GetTag($id:ID!, $id_type:TagIdType!) {
+					  tag(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->tag->term_id ],
+				'variables' => [ 'id' => $this->tag->term_id, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'tag.__typename', 'Tag' ),
 					$this->expectedField( 'tag.databaseId', $this->tag->term_id )
@@ -865,14 +866,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singleCategory' => [
 				'name' => 'singleCategory',
 				'query' => '
-					query GetCategory($id:ID!) {
-					  category(id:$id idType: DATABASE_ID) {
+					query GetCategory($id:ID!, $id_type:CategoryIdType!) {
+					  category(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->category->term_id ],
+				'variables' => [ 'id' => $this->category->term_id, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'category.__typename', 'Category' ),
 					$this->expectedField( 'category.databaseId', $this->category->term_id )
@@ -884,14 +885,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singleTestTaxonomyTerm' => [
 				'name' => 'singleTestTaxonomyTerm',
 				'query' => '
-					query GetTestTaxonomyTerm($id:ID!) {
-					  testTaxonomyTerm(id:$id idType: DATABASE_ID) {
+					query GetTestTaxonomyTerm($id:ID!, $id_type:TestTaxonomyTermIdType!) {
+					  testTaxonomyTerm(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->test_taxonomy_term->term_id ],
+				'variables' => [ 'id' => $this->test_taxonomy_term->term_id, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'testTaxonomyTerm.__typename', 'TestTaxonomyTerm' ),
 					$this->expectedField( 'testTaxonomyTerm.databaseId', $this->test_taxonomy_term->term_id )
@@ -928,8 +929,8 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'userWithPostsConnection' => [
 				'name' => 'userWithPostsConnection',
 				'query' => '
-					query GetUser($id:ID!) {
-					  user(id:$id idType:DATABASE_ID) {
+					query GetUser($id:ID!, $id_type:UserNodeIdTypeEnum!) {
+					  user(id:$id idType:$id_type) {
 				        __typename
 				        databaseId
 				        posts {
@@ -941,7 +942,7 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->admin->ID ],
+				'variables' => [ 'id' => $this->admin->ID, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'user.__typename', 'User' ),
 					$this->expectedField( 'user.databaseId', $this->admin->ID ),
@@ -957,8 +958,8 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'editorUserWithPostsConnection' => [
 				'name' => 'editorUserWithPostsConnection',
 				'query' => '
-					query GetUser($id:ID!) {
-					  user(id:$id idType:DATABASE_ID) {
+					query GetUser($id:ID!, $id_type:UserNodeIdTypeEnum!) {
+					  user(id:$id idType:$id_type) {
 				        __typename
 				        databaseId
 				        posts {
@@ -970,7 +971,7 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->editor->ID ],
+				'variables' => [ 'id' => $this->editor->ID, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'user.__typename', 'User' ),
 					$this->expectedField( 'user.databaseId', $this->editor->ID ),
@@ -986,14 +987,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'adminUserByDatabaseId' => [
 				'name' => 'adminUserByDatabaseId',
 				'query' => '
-					query GetUser($id:ID!) {
-					  user(id:$id idType:DATABASE_ID) {
+					query GetUser($id:ID!, $id_type:UserNodeIdTypeEnum!) {
+					  user(id:$id idType:$id_type) {
 				        __typename
 				        databaseId
 					  }
 					}
 				',
-				'variables' => [ 'id' => $this->admin->ID ],
+				'variables' => [ 'id' => $this->admin->ID, 'id_type' => 'DATABASE_ID', ],
 				'assertions' => [
 					$this->expectedField( 'user.__typename', 'User' ),
 					$this->expectedField( 'user.databaseId', $this->admin->ID ),
@@ -1090,15 +1091,16 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singleMenu' => [
 				'name' => 'singleMenu',
 				'query' => '
-					query GetMenu($id:ID!) {
-					  menu(id:$id idType: DATABASE_ID) {
+					query GetMenu($id:ID!, $id_type:MenuNodeIdTypeEnum!) {
+					  menu(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
 				'variables' => [
-					'id' => (int) $this->menu->term_id
+					'id' => (int) $this->menu->term_id,
+					'id_type' => 'DATABASE_ID',
 				]
 			],
 			'listMenu' => [
@@ -1131,8 +1133,8 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 			'singleMenuItem' => [
 				'name' => 'singleMenuItem',
 				'query' => '
-					query GetMenuItem($id:ID!) {
-					  menuItem(id:$id idType: DATABASE_ID) {
+					query GetMenuItem($id:ID!, $id_type:MenuItemNodeIdTypeEnum!) {
+					  menuItem(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					    parentDatabaseId
@@ -1141,13 +1143,14 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 				',
 				'variables' => [
 					'id' => $this->menu_item_1->ID,
+					'id_type' => 'DATABASE_ID',
 				]
 			],
 			'singleChildMenuItem' => [
 				'name' => 'singleChildMenuItem',
 				'query' => '
-					query GetMenuItem($id:ID!) {
-					  menuItem(id:$id idType: DATABASE_ID) {
+					query GetMenuItem($id:ID!, $id_type:MenuItemNodeIdTypeEnum!) {
+					  menuItem(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					    parentDatabaseId
@@ -1155,21 +1158,23 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 					}
 				',
 				'variables' => [
-					'id' => $this->child_menu_item->ID
+					'id' => $this->child_menu_item->ID,
+					'id_type' => 'DATABASE_ID',
 				]
 			],
 			'singleMediaItem' => [
 				'name' => 'singleMediaItem',
 				'query' => '
-					query GetSingleMediaItem($id:ID!) {
-					  mediaItem(id:$id idType:DATABASE_ID) {
+					query GetSingleMediaItem($id:ID!, $id_type:MediaItemIdType!) {
+					  mediaItem(id:$id idType:$id_type) {
 					    __typename
 					    databaseId
 					  }
 					}
 				',
 				'variables' => [
-					'id' => $this->mediaItem->ID
+					'id' => $this->mediaItem->ID,
+					'id_type' => 'DATABASE_ID',
 				],
 			],
 			'listMediaItem' => [
@@ -1274,7 +1279,7 @@ class WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches extends WPGraphQ
 
 			// we only want to do this if there are errors to surface
 			if ( array_key_exists( 'errors', $actual ) ) {
-				codecept_debug( [ 'actual' => $actual ]);
+				codecept_debug( [ 'query' => $query, 'actual' => $actual ]);
 				$this->assertArrayNotHasKey( 'errors', $actual );
 			}
 

--- a/tests/functional/DocumentCest.php
+++ b/tests/functional/DocumentCest.php
@@ -15,13 +15,14 @@ class DocumentCest {
 	public function saveQueryWithWhereClauseTest( FunctionalTester $I ) {
 		$I->wantTo( 'Save a graphql query containing a where clause and double quotes' );
 
-		$query = "{ posts(where: {tag: \"bees\"}) { nodes { id title uri content } } }";
+		$query = "query (\$tag: String!) { posts(where: {tag: \$tag}) { nodes { id title uri content } } }";
 		$query_alias = 'test-save-query-alias';
 
 		$I->dontSeeTermInDatabase( [ 'name' => 'graphql_query_alias' ] );
 		$I->sendPost('graphql', [
 			'query' => $query,
-			'queryId' => $query_alias
+			'queryId' => $query_alias,
+			'variables' => [ 'tag' => 'bees', ],
 		] );
 		$I->seeResponseContainsJson([
 			'data' => [

--- a/tests/functional/SaveQueryValidateCest.php
+++ b/tests/functional/SaveQueryValidateCest.php
@@ -59,7 +59,7 @@ class SaveQueryValidateCest {
 		] );
 		$I->seeResponseContainsJson([
 			'errors' => [
-				'message' => 'Validation Error: Argument "$id" should be a variable.'
+				'message' => 'Validation Error: Argument "id" should be a variable.'
 			]
 		]);
 	}
@@ -78,7 +78,7 @@ class SaveQueryValidateCest {
 		] );
 		$I->seeResponseContainsJson([
 			'errors' => [
-				'message' => 'Validation Error: Argument "$idType" should be a variable.'
+				'message' => 'Validation Error: Argument "idType" should be a variable.'
 			]
 		]);
 	}
@@ -97,7 +97,7 @@ class SaveQueryValidateCest {
 		] );
 		$I->seeResponseContainsJson([
 			'errors' => [
-				'message' => 'Validation Error: Argument "$idType" should be a variable.'
+				'message' => 'Validation Error: Argument "idType" should be a variable.'
 			]
 		]);
 	}
@@ -154,10 +154,29 @@ class SaveQueryValidateCest {
 			'post_status' => 'draft',
 		]);
 
-		$I->see('Validation Error: Argument "$id" should be a variable.', '//*[@id="plugin-message"]');
+		$I->see('Validation Error: Argument "id" should be a variable.', '//*[@id="plugin-message"]');
 		$I->dontSeeElement('//*[@id="message"]');
 		$I->dontSee('Post draft updated.');
 		$I->dontSee('Post published.');
 		$I->see('Publish immediately'); // does not have a publish date
+	}
+
+	public function saveQueryErrorsWhenIntValueShouldBeAVariableTest( FunctionalTester $I ) {
+		$query = '{ posts( first: 1 ) { nodes { title } } }';
+		$query_alias = 'test-save-query-alias';
+		$I->dontSeeTermInDatabase( [ 'name' => 'graphql_query_alias' ] );
+		$I->sendPost('graphql', [
+			'query' => $query,
+			'queryId' => $query_alias
+		] );
+		$I->dontSeePostInDatabase( [
+			'post_type'    => 'graphql_document',
+			'post_status'  => 'publish',
+		] );
+		$I->seeResponseContainsJson([
+			'errors' => [
+				'message' => 'Validation Error: Argument "first" should be a variable.'
+			]
+		]);
 	}
 }

--- a/tests/functional/SaveQueryValidateCest.php
+++ b/tests/functional/SaveQueryValidateCest.php
@@ -1,0 +1,125 @@
+<?php
+
+// "query FooQuery { post( id: "1", idType: DATABASE_ID) { title } }"   <-- this is the one we want to error on !!!!!
+// "query ($num: ID!) { post( id: "1", idType: DATABASE_ID) { title } }"
+// "query ($num: ID!) { post( id: $num, idType: DATABASE_ID) { title } }"
+//        looking for  [4] => argument: (id) ()\n            [5] => variable: (num)\n
+// "query ($num: ID!) { posts { edges { node { title } } } }"
+
+class SaveQueryValidateCest {
+	public function _before( FunctionalTester $I ) {
+		// Make sure that is gone.
+		$I->dontHavePostInDatabase(['post_title' => 'Hello world!']);
+
+		// clean up and persisted queries terms in the taxonomy
+		$I->dontHavePostInDatabase( [ 'post_type' => 'graphql_document' ] );
+		$I->dontHaveTermInDatabase( [ 'taxonomy' => 'graphql_query_alias'] );
+
+		$I->dontHaveOptionInDatabase( 'graphql_persisted_queries_section'  );
+	}
+
+	public function _after( FunctionalTester $I ) {
+		$I->dontHaveOptionInDatabase( 'graphql_persisted_queries_section'  );
+
+		// Clean up any saved query documents
+		$I->dontHavePostInDatabase( [ 'post_type' => 'graphql_document' ] );
+		$I->dontHaveTermInDatabase( [ 'taxonomy' => 'graphql_query_alias'] );
+	}
+
+	public function saveQueryWithArgumentMissingVariableTest( FunctionalTester $I ) {
+		$query = 'query { post( id: $num, idType: DATABASE_ID) { title } }';
+		$query_alias = 'test-save-query-alias';
+		$I->dontSeeTermInDatabase( [ 'name' => 'graphql_query_alias' ] );
+		$I->sendPost('graphql', [
+			'query' => $query,
+			'queryId' => $query_alias
+		] );
+		$I->dontSeePostInDatabase( [
+			'post_type'    => 'graphql_document',
+			'post_status'  => 'publish',
+		] );
+		$I->seeResponseContainsJson([
+			'errors' => [
+				'message' => 'Validation Error: Variable "$num" is not defined.'
+			]
+		]);
+	}
+
+	public function saveQueryMissingArgumentWithVariableTest( FunctionalTester $I ) {
+		$query = 'query ($num: ID!) { post( id: "1", idType: DATABASE_ID ) { title } }';
+		$query_alias = 'test-save-query-alias';
+		$I->dontSeeTermInDatabase( [ 'name' => 'graphql_query_alias' ] );
+		$I->sendPost('graphql', [
+			'query' => $query,
+			'queryId' => $query_alias
+		] );
+		$I->dontSeePostInDatabase( [
+			'post_type'    => 'graphql_document',
+			'post_status'  => 'publish',
+		] );
+		$I->seeResponseContainsJson([
+			'errors' => [
+				'message' => 'Validation Error: Argument "$id" should be a variable.'
+			]
+		]);
+	}
+
+	public function saveQueryWithArgumentWithVariableTest( FunctionalTester $I ) {
+		$query = 'query ($num: ID!) { post( id: $num, idType: DATABASE_ID) { title } }';
+		$query_alias = 'test-save-query-alias';
+
+		$post_id = $I->havePostInDatabase(['post_title' => 'Hello world!']);
+
+		$I->dontSeeTermInDatabase( [ 'name' => 'graphql_query_alias' ] );
+		$I->sendPost('graphql', [
+			'query' => $query,
+			'queryId' => $query_alias,
+			'variables' => [ "num" => $post_id ],
+		] );
+		$I->seeResponseContainsJson([
+			'data' => [
+				'post' => [
+					'title' => 'Hello world!',
+				]
+			]
+		]);
+		$I->seeTermInDatabase( [ 'name' => $query_alias ] );
+		$I->seePostInDatabase( [
+			'post_type'    => 'graphql_document',
+			'post_status'  => 'publish',
+			'post_content' => "query (\$num: ID!) {\n  post(id: \$num, idType: DATABASE_ID) {\n    title\n  }\n}\n",
+		] );
+	}
+
+	public function editorCreateNewQueryWithErrorWhenPublishSavesAsDraftTest( FunctionalTester $I ) {
+		$I->haveOptionInDatabase( 'graphql_persisted_queries_section', [ 'editor_display' => 'on' ] );
+
+		$post_title = 'test-post';
+		$query = 'query ($num: ID!) { post( id: "1", idType: DATABASE_ID ) { title } }';
+
+		// Create a new query in the admin editor
+		$I->loginAsAdmin();
+		$I->amOnPage( '/wp-admin/post-new.php?post_type=graphql_document');
+
+		// Add title should trigger auto-draft, but not save document
+		$I->fillField( "//input[@name='post_title']", $post_title );
+		$I->fillField( 'content', $query );
+
+		$I->dontSeePostInDatabase( ['post_title' => $post_title] );
+
+		// Publish post
+		$I->click('#publish');
+
+		// Because of error form (empty content), saves as draft
+		$I->seePostInDatabase( [
+			'post_title'  => $post_title,
+			'post_status' => 'draft',
+		]);
+
+		$I->see('Validation Error: Argument "$id" should be a variable.', '//*[@id="plugin-message"]');
+		$I->dontSeeElement('//*[@id="message"]');
+		$I->dontSee('Post draft updated.');
+		$I->dontSee('Post published.');
+		$I->see('Publish immediately'); // does not have a publish date
+	}
+}

--- a/tests/functional/SaveQueryValidateCest.php
+++ b/tests/functional/SaveQueryValidateCest.php
@@ -59,7 +59,7 @@ class SaveQueryValidateCest {
 		] );
 		$I->seeResponseContainsJson([
 			'errors' => [
-				'message' => 'Validation Error: Argument "id" should be a variable.'
+				'message' => 'Validation Error: Argument "id" value should use a variable.'
 			]
 		]);
 	}
@@ -78,7 +78,7 @@ class SaveQueryValidateCest {
 		] );
 		$I->seeResponseContainsJson([
 			'errors' => [
-				'message' => 'Validation Error: Argument "idType" should be a variable.'
+				'message' => 'Validation Error: Argument "idType" value should use a variable.'
 			]
 		]);
 	}
@@ -97,7 +97,7 @@ class SaveQueryValidateCest {
 		] );
 		$I->seeResponseContainsJson([
 			'errors' => [
-				'message' => 'Validation Error: Argument "idType" should be a variable.'
+				'message' => 'Validation Error: Argument "idType" value should use a variable.'
 			]
 		]);
 	}
@@ -154,7 +154,7 @@ class SaveQueryValidateCest {
 			'post_status' => 'draft',
 		]);
 
-		$I->see('Validation Error: Argument "id" should be a variable.', '//*[@id="plugin-message"]');
+		$I->see('Validation Error: Argument "id" value should use a variable.', '//*[@id="plugin-message"]');
 		$I->dontSeeElement('//*[@id="message"]');
 		$I->dontSee('Post draft updated.');
 		$I->dontSee('Post published.');
@@ -175,7 +175,7 @@ class SaveQueryValidateCest {
 		] );
 		$I->seeResponseContainsJson([
 			'errors' => [
-				'message' => 'Validation Error: Argument "first" should be a variable.'
+				'message' => 'Validation Error: Argument "first" value should use a variable.'
 			]
 		]);
 	}

--- a/tests/wpunit/DocumentGarbageCollectionTest.php
+++ b/tests/wpunit/DocumentGarbageCollectionTest.php
@@ -55,7 +55,7 @@ class DocumentGarbageCollectionTest extends \Codeception\TestCase\WPTestCase {
 					[
 						'post_type' => 'graphql_document',
 						'post_date' => $date_string,
-						'post_content' => sprintf( "query Saved_%d { typename }", $counter ),
+						'post_content' => sprintf( "query Saved_%d { __typename }", $counter ),
 						'post_title' => sprintf( "query %d", $counter ),
 					]
 				);
@@ -69,7 +69,7 @@ class DocumentGarbageCollectionTest extends \Codeception\TestCase\WPTestCase {
 				[
 					'post_type' => 'graphql_document',
 					'post_date' => $date_string,
-					'post_content' => sprintf( "query Saved_%d { typename }", $counter ),
+					'post_content' => sprintf( "query Saved_%d { __typename }", $counter ),
 					'post_title' => sprintf( "query %d", $counter ),
 				]
 			);

--- a/tests/wpunit/DocumentTest.php
+++ b/tests/wpunit/DocumentTest.php
@@ -8,7 +8,7 @@ class DocumentTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testThrowNeedsVariableUsingWhere() {
         $this->expectException( \GraphQL\Server\RequestError::class );
-        $this->expectExceptionMessage( 'Validation Error: Argument "title" value should use a variable.' );
+        $this->expectExceptionMessage( 'Validation Error: Argument "where" value should use a variable.' );
 		$document = new Document();
 
         $query = 'query one {

--- a/tests/wpunit/DocumentTest.php
+++ b/tests/wpunit/DocumentTest.php
@@ -8,7 +8,7 @@ class DocumentTest extends \Codeception\TestCase\WPTestCase {
 
 	public function testThrowNeedsVariableUsingWhere() {
         $this->expectException( \GraphQL\Server\RequestError::class );
-        $this->expectExceptionMessage( 'Validation Error: Argument "where" value should use a variable.' );
+        $this->expectExceptionMessage( 'Validation Error: Argument "title" value should use a variable.' );
 		$document = new Document();
 
         $query = 'query one {

--- a/tests/wpunit/DocumentTest.php
+++ b/tests/wpunit/DocumentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace WPGraphQL\SmartCache;
+
+use WPGraphQL\SmartCache\Document;
+
+class DocumentTest extends \Codeception\TestCase\WPTestCase {
+
+	public function testThrowNeedsVariableUsingWhere() {
+        $this->expectException( \GraphQL\Server\RequestError::class );
+        $this->expectExceptionMessage( 'Validation Error: Argument "title" value should use a variable.' );
+		$document = new Document();
+
+        $query = 'query one {
+            posts(where: {title: "hello"}) {
+                nodes {
+                    title
+                }
+            }
+        }';
+
+		$document->valid_or_throw( $query, '1' );
+    }
+
+	public function testSuccessUsingVariablesWithWhere() {
+		$document = new Document();
+        $query = 'query one($tag: String!) {
+            posts(where: {tag: $tag}) {
+                nodes {
+                    title
+                }
+            }
+        }';
+
+        // This does not throw error
+		$pretty_print = $document->valid_or_throw( $query, '1' );
+        $this->assertEquals("query one(\$tag: String!) {\n  posts(where: {tag: \$tag}) {\n    nodes {\n      title\n    }\n  }\n}\n", $pretty_print);
+    }
+
+	public function testThrowNeedsVariable() {
+        $this->expectException( \GraphQL\Server\RequestError::class );
+        $this->expectExceptionMessage( 'Validation Error: Argument "id" value should use a variable.' );
+		$document = new Document();
+
+        $query = 'query one {
+            post(id: "1", idType: DATABASE_ID) {
+                title
+            }
+        }';
+
+		$document->valid_or_throw( $query, '1' );
+    }
+}

--- a/tests/wpunit/MutationCreateDocumentTest.php
+++ b/tests/wpunit/MutationCreateDocumentTest.php
@@ -77,7 +77,7 @@ class MutationCreateDocumentTest extends \Codeception\TestCase\WPTestCase {
         $query_title = "cest test mutation";
         $variables = [
             "input" => [
-                "content" => "query my_query_1 { __typename, uri, title }",
+                "content" => "query my_query_1 { themes { edges { node { id } } } }",
                 "alias" => [
                     "foo",
                     "bar"
@@ -101,7 +101,7 @@ class MutationCreateDocumentTest extends \Codeception\TestCase\WPTestCase {
         // Trying to create/save another document with same query string, should throw error
         $variables = [
             "input" => [
-                "content" => "query my_query_1 { __typename, uri, title }",
+                "content" => "query my_query_1 { themes { edges { node { id } } } }",
             ]
         ];
 
@@ -114,7 +114,7 @@ class MutationCreateDocumentTest extends \Codeception\TestCase\WPTestCase {
         // Trying to create/save another document with alias that is already in use, should throw error
         $variables = [
             "input" => [
-                "content" => "query my_query_2 { __typename, uri, title }",
+                "content" => "query my_query_2 { themes { edges { node { id } } } }",
                 "alias" => [
                     "foo",
                 ],
@@ -145,7 +145,7 @@ class MutationCreateDocumentTest extends \Codeception\TestCase\WPTestCase {
 
         $variables = [
             "input" => [
-                "content" => "query my_query_1 { __typename, uri, title }",
+                "content" => "query my_query_1 { themes { edges { node { id } } } }",
                 "status" => "PUBLISH",
                 "grant" => "allow"
             ]
@@ -222,7 +222,7 @@ class MutationCreateDocumentTest extends \Codeception\TestCase\WPTestCase {
 
         $variables = [
             "input" => [
-                "content" => "query my_query_1 { __typename, uri, title }",
+                "content" => "query my_query_1 { themes { edges { node { id } } } }",
                 "status" => "PUBLISH",
                 "maxAgeHeader" => 100
             ]
@@ -299,7 +299,7 @@ class MutationCreateDocumentTest extends \Codeception\TestCase\WPTestCase {
 
         $variables = [
             "input" => [
-                "content" => "query my_query_1 { __typename, uri, title }",
+                "content" => "query my_query_1 { __typename }",
                 "status" => "PUBLISH",
                 "description" => "foo bar description"
             ]

--- a/tests/wpunit/PostCacheInvalidationTest.php
+++ b/tests/wpunit/PostCacheInvalidationTest.php
@@ -725,7 +725,7 @@ class PostCacheInvalidationTest extends \TestCase\WPGraphQLSmartCache\TestCase\W
 		]);
 
 		$query = $this->getQuery( 'userWithPostsConnection' );
-		$variables = [ 'id' => $new_user->ID ];
+		$variables = [ 'id' => $new_user->ID, 'id_type' => 'DATABASE_ID' ];
 
 		$cache_key = $this->collection->build_key( null, $query, $variables );
 


### PR DESCRIPTION
When processing a persisted query document string for saving, run the validation rules on the string.  Add a new rule to error for arguments that are present in operations but instead should be a variable instead.  Return the graphql Error or display the error in the editor.

Github [issue](https://github.com/wp-graphql/wp-graphql-smart-cache/issues/224)