### PR TITLE
ci: Add WP 6.3 to test matrix. Update docs to reflect

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -27,7 +27,7 @@ MYSQL_USER=${DB_USER}
 MYSQL_PASSWORD=${DB_PASSWORD}
 
 # docker container env vars
-WP_VERSION=6.1
-PHP_VERSION=8.1
+WP_VERSION=6.3
+PHP_VERSION=8.2
 WPGRAPHQL_VERSION=latest
 DATA_DUMP_DIR=/var/www/html/wp-content/plugins/wp-graphql-smart-cache/tests/_data

--- a/.env.testing
+++ b/.env.testing
@@ -54,7 +54,7 @@ MYSQL_USER=${DB_USER}
 MYSQL_PASSWORD=${DB_PASSWORD}
 
 # docker container env vars
-WP_VERSION=6.1
-PHP_VERSION=8.1
+WP_VERSION=6.3
+PHP_VERSION=8.2
 WPGRAPHQL_VERSION=latest
 DATA_DUMP_DIR=/var/www/html/wp-content/plugins/wp-graphql-smart-cache/tests/_data

--- a/.github/workflows/tests-wordpress.yml
+++ b/.github/workflows/tests-wordpress.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2', '8.1', '8.0' ]
+        php: [ '8.2', '8.1' ]
         wordpress: [ '6.3', '6.2', '6.1' ]
         wpgraphql_version: [ 'latest' ]
         include:
@@ -25,6 +25,10 @@ jobs:
           # so we include WP 5.9 manually instead of in the matrix
           - php: '8.1'
             wordpress: '5.9'
+          - php: '8.0'
+            wordpress: '6.2'
+          - php: '8.0'
+            wordpress: '6.1'
           - php: '7.4'
             wordpress: '5.9'
     steps:

--- a/.github/workflows/tests-wordpress.yml
+++ b/.github/workflows/tests-wordpress.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.0' ]
-        wordpress: [ '6.2', '6.1' ]
+        php: [ '8.2', '8.1', '8.0' ]
+        wordpress: [ '6.3', '6.2', '6.1' ]
         wpgraphql_version: [ 'latest' ]
         include:
           # WordPress isn't pushing php 8.2 and WP 5.9 to Docker

--- a/.github/workflows/upload-plugin-zip.yml
+++ b/.github/workflows/upload-plugin-zip.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.2
           tools: composer
       - name: Install PHP dependencies
         run: |

--- a/.github/workflows/wordpress-coding-standards.yml
+++ b/.github/workflows/wordpress-coding-standards.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check code
     strategy:
       matrix:
-        php: [ 8.0 ]
+        php: [ 8.2 ]
 
     steps:
       - name: Checkout

--- a/composer.lock
+++ b/composer.lock
@@ -1645,16 +1645,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "66ff5aab0dd10659aff0efe3ff101819db192dfe"
+                "reference": "f494398dbaaead9e5ff16a18002d11634e8358e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/66ff5aab0dd10659aff0efe3ff101819db192dfe",
-                "reference": "66ff5aab0dd10659aff0efe3ff101819db192dfe",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/f494398dbaaead9e5ff16a18002d11634e8358e6",
+                "reference": "f494398dbaaead9e5ff16a18002d11634e8358e6",
                 "shasum": ""
             },
             "require": {
@@ -1696,11 +1696,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-08-02T14:57:32+00:00"
+            "time": "2023-08-11T14:48:51+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1746,7 +1746,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1794,7 +1794,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1840,16 +1840,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v10.18.0",
+            "version": "v10.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "9ce4a26975a919ec33ed21307633ac02208537a8"
+                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/9ce4a26975a919ec33ed21307633ac02208537a8",
-                "reference": "9ce4a26975a919ec33ed21307633ac02208537a8",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
+                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
                 "shasum": ""
             },
             "require": {
@@ -1907,7 +1907,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-08-08T14:14:45+00:00"
+            "time": "2023-08-14T21:56:59+00:00"
         },
         {
             "name": "ivome/graphql-relay-php",
@@ -2350,24 +2350,28 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.68.1",
+            "version": "2.69.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "4f991ed2a403c85efbc4f23eb4030063fdbe01da"
+                "reference": "4308217830e4ca445583a37d1bf4aff4153fa81c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4f991ed2a403c85efbc4f23eb4030063fdbe01da",
-                "reference": "4f991ed2a403c85efbc4f23eb4030063fdbe01da",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4308217830e4ca445583a37d1bf4aff4153fa81c",
+                "reference": "4308217830e4ca445583a37d1bf4aff4153fa81c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
+                "psr/clock": "^1.0",
                 "symfony/polyfill-mbstring": "^1.0",
                 "symfony/polyfill-php80": "^1.16",
                 "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
             },
             "require-dev": {
                 "doctrine/dbal": "^2.0 || ^3.1.4",
@@ -2448,7 +2452,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-20T18:29:04+00:00"
+            "time": "2023-08-03T09:00:52+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3428,6 +3432,54 @@
                 }
             ],
             "time": "2023-07-10T04:04:23+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -1645,7 +1645,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1700,7 +1700,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1746,7 +1746,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1794,7 +1794,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1840,16 +1840,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f"
+                "reference": "38d3e064b7b9420d2173f23a31a435bde221b56d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
-                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/38d3e064b7b9420d2173f23a31a435bde221b56d",
+                "reference": "38d3e064b7b9420d2173f23a31a435bde221b56d",
                 "shasum": ""
             },
             "require": {
@@ -1907,7 +1907,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-08-14T21:56:59+00:00"
+            "time": "2023-08-21T13:45:59+00:00"
         },
         {
             "name": "ivome/graphql-relay-php",
@@ -2951,16 +2951,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.29",
+            "version": "1.10.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1"
+                "reference": "2910afdd3fe33e5afd71c09f3fb0d0845b48c410"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
-                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2910afdd3fe33e5afd71c09f3fb0d0845b48c410",
+                "reference": "2910afdd3fe33e5afd71c09f3fb0d0845b48c410",
                 "shasum": ""
             },
             "require": {
@@ -3009,7 +3009,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-14T13:24:11+00:00"
+            "time": "2023-08-22T13:48:25+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3432,54 +3432,6 @@
                 }
             ],
             "time": "2023-08-19T07:10:56+00:00"
-        },
-        {
-            "name": "psr/clock",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/clock.git",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Clock\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for reading the clock.",
-            "homepage": "https://github.com/php-fig/clock",
-            "keywords": [
-                "clock",
-                "now",
-                "psr",
-                "psr-20",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/clock/issues",
-                "source": "https://github.com/php-fig/clock/tree/1.0.0"
-            },
-            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/clock",
@@ -6841,16 +6793,16 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v14.11.9",
+            "version": "v14.11.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "ff91c9f3cf241db702e30b2c42bcc0920e70ac70"
+                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/ff91c9f3cf241db702e30b2c42bcc0920e70ac70",
-                "reference": "ff91c9f3cf241db702e30b2c42bcc0920e70ac70",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/d9c2fdebc6aa01d831bc2969da00e8588cffef19",
+                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19",
                 "shasum": ""
             },
             "require": {
@@ -6870,8 +6822,7 @@
                 "phpunit/phpunit": "^7.2 || ^8.5",
                 "psr/http-message": "^1.0",
                 "react/promise": "2.*",
-                "simpod/php-coveralls-mirror": "^3.0",
-                "squizlabs/php_codesniffer": "3.5.4"
+                "simpod/php-coveralls-mirror": "^3.0"
             },
             "suggest": {
                 "psr/http-message": "To use standard GraphQL server",
@@ -6895,7 +6846,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.9"
+                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.10"
             },
             "funding": [
                 {
@@ -6903,7 +6854,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-01-06T12:12:50+00:00"
+            "time": "2023-07-05T14:23:37+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -7142,23 +7093,23 @@
         },
         {
             "name": "wp-graphql/wp-graphql",
-            "version": "v1.14.10",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-graphql/wp-graphql.git",
-                "reference": "f70ac589c6a67892b3f1e3c8415f1d379f279bee"
+                "reference": "45a2e9e188fa5b2c6470efb9e53fac3691bbb610"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/f70ac589c6a67892b3f1e3c8415f1d379f279bee",
-                "reference": "f70ac589c6a67892b3f1e3c8415f1d379f279bee",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/45a2e9e188fa5b2c6470efb9e53fac3691bbb610",
+                "reference": "45a2e9e188fa5b2c6470efb9e53fac3691bbb610",
                 "shasum": ""
             },
             "require": {
                 "appsero/client": "1.2.1",
                 "ivome/graphql-relay-php": "0.6.0",
                 "php": "^7.1 || ^8.0",
-                "webonyx/graphql-php": "14.11.9"
+                "webonyx/graphql-php": "14.11.10"
             },
             "require-dev": {
                 "automattic/vipwpcs": "^2.2",
@@ -7216,9 +7167,9 @@
             "description": "GraphQL API for WordPress",
             "support": {
                 "issues": "https://github.com/wp-graphql/wp-graphql/issues",
-                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.14.10"
+                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.15.0"
             },
-            "time": "2023-08-03T22:09:10+00:00"
+            "time": "2023-08-23T05:42:30+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,21 +30,21 @@ Use one of the following commands to build the local images for the app and test
 
 Build all images in the docker compose configuration. Requires having built your own wp-graphql local images.
 
-    WP_VERSION=5.9  PHP_VERSION=8.0 docker-compose build --build-arg WP_VERSION=5.9 --build-arg PHP_VERSION=8.0
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker-compose build --build-arg WP_VERSION=6.3 --build-arg PHP_VERSION=8.2
 
 Build fresh docker image without cache by adding `--no-cache`.
 
-    WP_VERSION=5.9  PHP_VERSION=8.0 docker-compose build --build-arg WP_VERSION=5.9 --build-arg PHP_VERSION=8.0 --no-cache
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker-compose build --build-arg WP_VERSION=6.3 --build-arg PHP_VERSION=8.2 --no-cache
 
 Build using wp-graphql image from docker hub registry, instead of building your own wp-graphql image.
 
-    WP_VERSION=5.9  PHP_VERSION=8.0 docker-compose build --build-arg WP_VERSION=5.9 --build-arg PHP_VERSION=8.0 --build-arg DOCKER_REGISTRY=ghcr.io/wp-graphql/
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker-compose build --build-arg WP_VERSION=6.3 --build-arg PHP_VERSION=8.2 --build-arg DOCKER_REGISTRY=ghcr.io/wp-graphql/
 
 ### docker
 
 Use this command if you want to build a specific image. If you ran the docker-compose command above, this is not necessary.
 
-    docker build -f docker/Dockerfile -t wp-graphql-smart-cache:latest-wp5.6-php8.0 --build-arg WP_VERSION=5.6 --build-arg PHP_VERSION=8.0 .
+    docker build -f docker/Dockerfile -t wp-graphql-smart-cache:latest-wp6.3-php8.2 --build-arg WP_VERSION=6.3 --build-arg PHP_VERSION=8.2 .
 
 ## Run
 
@@ -54,7 +54,7 @@ Use one of the following to start the WP app with the plugin installed and runni
 
 This is an example of specifying the WP and PHP version for the wp-graphql images.
 
-    WP_VERSION=5.9 PHP_VERSION=8.0 docker compose up app
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker compose up app
 
 ## Shell
 
@@ -62,7 +62,7 @@ Use one of the following if you want to access the WP app with bash command shel
 
     docker-compose run app bash
 
-    WP_VERSION=5.9 PHP_VERSION=8.0 docker-compose run app bash
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker-compose run app bash
 
 ## Stop
 
@@ -90,21 +90,21 @@ If you ran the docker-compose build command, above, this step is not necessary a
 
 ### docker
 
-    WP_VERSION=5.9 PHP_VERSION=8.0 docker build -f docker/Dockerfile.testing -t wp-graphql-smart-cache-testing:latest-wp5.7.2-php7.4 --build-arg WP_VERSION=5.9 --build-arg PHP_VERSION=8.0 --build-arg DOCKER_REGISTRY=ghcr.io/wp-graphql/ .
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker build -f docker/Dockerfile.testing -t wp-graphql-smart-cache-testing:latest-wp5.7.2-php7.4 --build-arg WP_VERSION=6.3 --build-arg PHP_VERSION=8.2 --build-arg DOCKER_REGISTRY=ghcr.io/wp-graphql/ .
 
-    docker build -f docker/Dockerfile.testing -t wp-graphql-smart-cache-testing:latest-wp5.7.2-php7.4 --build-arg WP_VERSION=5.9 --build-arg PHP_VERSION=8.0 --build-arg DOCKER_REGISTRY=ghcr.io/wp-graphql/ .
+    docker build -f docker/Dockerfile.testing -t wp-graphql-smart-cache-testing:latest-wp5.7.2-php7.4 --build-arg WP_VERSION=6.3 --build-arg PHP_VERSION=8.2 --build-arg DOCKER_REGISTRY=ghcr.io/wp-graphql/ .
 
 ## Run
 
 Use one of these commands to run the test suites.
 
-    WP_VERSION=5.9 PHP_VERSION=8.0 docker-compose run testing
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker-compose run testing
 
     docker-compose run testing
 
 Use the DEBUG environment variable to see the codeception debug during tests.
 
-    WP_VERSION=5.9 PHP_VERSION=8.0 docker-compose run -e DEBUG=1 testing
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker-compose run -e DEBUG=1 testing
 
 ## Shell
 
@@ -114,4 +114,4 @@ Use one of the following if you want to access the WP testing app with bash comm
 
 This is an example of specifying the WP and PHP version for the wp-graphql images.
 
-    WP_VERSION=5.9 PHP_VERSION=8.0 docker-compose run --entrypoint bash testing
+    WP_VERSION=6.3 PHP_VERSION=8.2 docker-compose run --entrypoint bash testing


### PR DESCRIPTION
Add WP 6.3 to the CI/CD test matrix.  Change documentation references for the WP_VERSION and PHP_VERSION variables to 6.3 and 8.2, respectively.  

closes #250 

[dependency](https://github.com/wp-graphql/wp-graphql/pull/2907) - on wp-graphql 6.3 image being merged and tagged in an upcoming release.