### PR TITLE
When published query is edited, offer save as draft

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1645,7 +1645,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1700,7 +1700,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1746,7 +1746,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1794,7 +1794,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1840,16 +1840,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v10.19.0",
+            "version": "v10.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f"
+                "reference": "38d3e064b7b9420d2173f23a31a435bde221b56d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
-                "reference": "0a8526d55756955fcec6be7c2c6cd14d915c8c0f",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/38d3e064b7b9420d2173f23a31a435bde221b56d",
+                "reference": "38d3e064b7b9420d2173f23a31a435bde221b56d",
                 "shasum": ""
             },
             "require": {
@@ -1907,7 +1907,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-08-14T21:56:59+00:00"
+            "time": "2023-08-21T13:45:59+00:00"
         },
         {
             "name": "ivome/graphql-relay-php",
@@ -2951,16 +2951,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.29",
+            "version": "1.10.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1"
+                "reference": "2910afdd3fe33e5afd71c09f3fb0d0845b48c410"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
-                "reference": "ee5d8f2d3977fb09e55603eee6fb53bdd76ee9c1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2910afdd3fe33e5afd71c09f3fb0d0845b48c410",
+                "reference": "2910afdd3fe33e5afd71c09f3fb0d0845b48c410",
                 "shasum": ""
             },
             "require": {
@@ -3009,7 +3009,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-14T13:24:11+00:00"
+            "time": "2023-08-22T13:48:25+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -84,9 +84,10 @@ class Editor {
 
 			$data['post_content'] = $document->valid_or_throw( $post['post_content'], $post['ID'] );
 
-			// If post is already published, and graphql query string is different on save, save as a new post/clone/copy.
-			if ( 'publish' === $existing_post['post_status'] && $data['post_content'] !== $existing_post['post_content'] ) {
+			// If post is already published and saving as published, and graphql query string is different on save
+			if ( 'publish' === $existing_post['post_status'] && 'publish' === $post['post_status'] && $data['post_content'] !== $existing_post['post_content'] ) {
 				
+				// If selected to save as new
 				// phpcs:ignore
 				if ( isset( $_POST['graphql_query_save_new'] ) && 'save_as_new' === $_POST['graphql_query_save_new'] ) {
 					// phpcs:ignore

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -395,6 +395,10 @@ class Editor {
 		return $settings;
 	}
 
+	/**
+	 * @param \WP_Post $post
+	 * @return void
+	 */
 	public function draw_save_as_new_checkbox_cb( $post ) {
 		$post_id = get_the_ID();
 
@@ -411,6 +415,7 @@ class Editor {
 		$html .= '<label for="graphql_query_save_new">Save As New</label><br >';
 		$html .= '</div>';
 
+		/** @var array[] */
 		$allowed_html = [
 			'div'   => [
 				'class' => true,

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -85,8 +85,7 @@ class Editor {
 			$data['post_content'] = $document->valid_or_throw( $post['post_content'], $post['ID'] );
 
 			// If post is already published and saving as published, and graphql query string is different on save
-			if ( 'publish' === $existing_post['post_status'] && 'publish' === $post['post_status'] && $data['post_content'] !== $existing_post['post_content'] ) {
-				
+			if ( 'publish' === $existing_post['post_status'] && 'publish' === $post['post_status'] ) {
 				// If selected to save as new
 				// phpcs:ignore
 				if ( isset( $_POST['graphql_query_save_new'] ) && 'save_as_new' === $_POST['graphql_query_save_new'] ) {
@@ -109,8 +108,9 @@ class Editor {
 					// Redirect to the new post edit page after save
 					wp_safe_redirect( admin_url( sprintf( '/post.php?post=%d&action=edit', $new_post_id ) ) );
 					exit;
+				}
 
-				} else {
+				if ( $data['post_content'] !== $existing_post['post_content'] ) {
 					throw new RequestError( __( 'Changing query for published query is not allowed. Select the save as new and publish again.', 'wp-graphql-smart-cache' ) );
 				}
 			}
@@ -413,7 +413,7 @@ class Editor {
 
 		$html  = '<div class="misc-pub-section misc-pub-section-last">';
 		$html .= '<input type="checkbox" id="graphql_query_save_new" name="graphql_query_save_new" value="save_as_new">';
-		$html .= '<label for="graphql_query_save_new">Save As New</label><br >';
+		$html .= '<label for="graphql_query_save_new">Save As Draft</label><br >';
 		$html .= '</div>';
 
 		/** @var array[] */

--- a/src/Document/Group.php
+++ b/src/Document/Group.php
@@ -51,4 +51,16 @@ class Group {
 		$item = get_the_terms( $post_id, self::TAXONOMY_NAME );
 		return ! is_wp_error( $item ) && isset( $item[0] ) && property_exists( $item[0], 'name' ) ? $item[0]->name : '';
 	}
+
+	/**
+	 * Save the data
+	 *
+	 * @param int $post_id
+	 * @param string $value
+	 * @return array|false|\WP_Error Array of term taxonomy IDs of affected terms. WP_Error or false on failure.
+	 */
+	public function save( $post_id, $value ) {
+		return wp_set_post_terms( $post_id, $value, self::TAXONOMY_NAME );
+	}
+
 }


### PR DESCRIPTION
For a saved query string that is in published state, when saving, reject the save if the query string has changed.  Show an error message at the top.

Also add a 'save as draft' option for save.

closes #254 

![Screenshot 2023-08-22 at 4 08 45 PM](https://github.com/wp-graphql/wp-graphql-smart-cache/assets/749603/708b747b-67bd-4935-af8e-098e07064721)
