### PR TITLE
Add build-plugin command to set up no-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,9 @@
     "phpstan": [
       "phpstan analyze --ansi --memory-limit=1G"
     ],
+    "build-plugin": [
+      "composer install --no-dev --optimize-autoloader && composer run-script zip && composer install"
+    ],
     "zip": [
       "mkdir -p plugin-build/wpgraphql-smart-cache",
       "rsync -rc --exclude-from=.distignore --exclude=plugin-build . plugin-build/wpgraphql-smart-cache/ --delete --delete-excluded -v",


### PR DESCRIPTION
Add a composer command wrapper around the zip command to set up the environment with --no-dev when. build the command.    Similar to a command that exists in wpgraphql-acf.

Followup work to this [issue](https://github.com/wp-graphql/wp-graphql-smart-cache/issues/256).