### PR TITLE
Remove invalid namespaces from autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,7 @@
     "license": "GPL-3.0-or-later",
     "autoload": {
         "psr-4": {
-            "WPGraphQL\\PersistedQueries\\": "src/",
-            "WPGraphQL\\Cache\\": "src/Cache",
-            "WPGraphQL\\SmartCache\\": "src"
+            "WPGraphQL\\SmartCache\\": "src/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
Namespaces: https://github.com/search?q=repo%3Awp-graphql%2Fwp-graphql-smart-cache%20path%3A%2F%5Esrc%5C%2F%2F%20namespace&type=code
