### PR TITLE
release: v1.2.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: WPGraphQL, Cache, API, Invalidation, Persisted Queries, GraphQL, Performan
 Requires at least: 5.6
 Tested up to: 6.4.2
 Requires PHP: 7.4
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,17 @@ This release removes a lot of code that has since been released as part of WPGra
 In order to use v0.2.0+ of WPGraphQL Smart Cache, you will need WPGraphQL v1.12.0 or newer.
 
 == Changelog ==
+
+= 1.2.1 =
+
+**Chores / Bugfixes**
+
+- [#266](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/266): ci: update tests to run against WordPres 6.4
+- [#266](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/266): fix: ensure store_content() is passed a string to adhere to phpstan standards
+- [#262](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/262): fix: remove invalid namespaces from autoloading. Thanks @szepeviktor!
+- [#251](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/251): ci: add WP 6.3 to test matrix
+- [#258](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/258): ci: add build-plugin command to set up no-dev
+
 
 = 1.2.0 =
 

--- a/wp-graphql-smart-cache.php
+++ b/wp-graphql-smart-cache.php
@@ -11,7 +11,7 @@
  * Requires PHP: 7.4
  * Text Domain: wp-graphql-smart-cache
  * Domain Path: /languages
- * Version: 1.2.0
+ * Version: 1.2.1
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -46,7 +46,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 if ( ! defined( 'WPGRAPHQL_SMART_CACHE_VERSION' ) ) {
-	define( 'WPGRAPHQL_SMART_CACHE_VERSION', '1.2.0' );
+	define( 'WPGRAPHQL_SMART_CACHE_VERSION', '1.2.1' );
 }
 
 if ( ! defined( 'WPGRAPHQL_SMART_CACHE_WPGRAPHQL_REQUIRED_MIN_VERSION' ) ) {


### PR DESCRIPTION
# Release Notes

### Chores / Bugfixes**

- [#266](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/266): ci: update tests to run against WordPres 6.4
- [#266](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/266): fix: ensure store_content() is passed a string to adhere to phpstan standards
- [#262](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/262): fix: remove invalid namespaces from autoloading. Thanks @szepeviktor!
- [#251](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/251): ci: add WP 6.3 to test matrix
- [#258](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/258): ci: add build-plugin command to set up no-dev
