### PR TITLE
feat: force enable query analyzer

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -82,9 +82,7 @@ class Settings {
 		$path = function_exists( 'get_graphql_setting' ) ? \get_graphql_setting( 'graphql_endpoint', 'graphql', 'graphql_general_settings' ) : 'graphql';
 		return '/' . $path;
 	}
-
-	public $fields;
-
+	
 	/**
 	 * @return void
 	 */

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -342,10 +342,12 @@ class Settings {
 	 *
 	 * @return mixed|string
 	 */
-	public function filter_graphql_query_analyzer_enabled_value( $value, $default_value, string $option_name, array $section_fields, string $section_name ) {
+	public function filter_graphql_query_analyzer_enabled_value( $value, $default_value, string $option_name, $section_fields, $section_name ) {
 		if ( 'query_analyzer_enabled' !== $option_name ) {
 			return $value;
 		}
+
+		// graphql_query_analyzer needs to be on for WPGraphQL Smart Cache to properly tag and invalidate caches
 		return 'on';
 	}
 }

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -82,7 +82,7 @@ class Settings {
 		$path = function_exists( 'get_graphql_setting' ) ? \get_graphql_setting( 'graphql_endpoint', 'graphql', 'graphql_general_settings' ) : 'graphql';
 		return '/' . $path;
 	}
-	
+
 	/**
 	 * @return void
 	 */
@@ -91,6 +91,7 @@ class Settings {
 		// Filter the graphql_query_analyzer setting to be on if WPGraphQL Smart Cache is active
 		add_filter( 'graphql_setting_field_config', [ $this, 'filter_graphql_query_analyzer_enabled_field' ], 10, 3 );
 		add_filter( 'graphql_get_setting_section_field_value', [ $this, 'filter_graphql_query_analyzer_enabled_value' ], 10, 5 );
+
 		// Add to the wp-graphql admin settings page
 		add_action(
 			'graphql_register_settings',

--- a/tests/wpunit/AdminSettingsCacheTest.php
+++ b/tests/wpunit/AdminSettingsCacheTest.php
@@ -36,4 +36,19 @@ class AdminSettingsCacheTest extends \Codeception\TestCase\WPTestCase {
 		add_option( 'graphql_cache_section', [ 'cache_toggle' => 'on' ] );
 		$this->assertTrue( Settings::caching_enabled() );
 	}
+
+	public function testQueryAnalyzerSettingIsForcedOn() {
+
+		// disable debug mode
+		add_filter( 'graphql_debug_enabled', '__return_false' );
+
+		// assert that debug mode is off
+		$this->assertFalse( \WPGraphQL::debug() );
+
+		// update the setting to disable query analyzer
+		update_option( 'graphql_general_settings', [ 'query_analyzer_enabled', 'off' ] );
+
+		// assert that the query analyzer is still enabled, even though the setting is turned off
+		$this->assertTrue( \WPGraphQL\Utils\QueryAnalyzer::is_enabled() );
+	}
 }


### PR DESCRIPTION
This force enables the GraphQL Query Analyzer when WPGraphQL Smart Cache is active. 

In v1.20.0 of WPGraphQL the GraphQL Query Analyzer became optional, causing some users of WPGraphQL Smart Cache to lose the X-GraphQL-Keys header used by cache tagging and cache invalidation. 

This force enables the Query Analyzer when using WPGraphQL Smart cache, ensuring that the keys are generated and output in the headers.

Closes: #269 #268 

Related: 
- https://github.com/wp-graphql/wp-graphql/pull/3008
- https://github.com/wp-graphql/wp-graphql/pull/3025