### PR TITLE
fix: invalidate caches for menu items

### DIFF
--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -896,7 +896,7 @@ class Invalidation {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function on_menu_item_added_to_menu_cb( int $object_id, int $tt_id, string $taxonomy  ): void {
+	public function on_menu_item_added_to_menu_cb( int $object_id, int $tt_id, string $taxonomy ): void {
 
 		if ( 'nav_menu' !== $taxonomy ) {
 			return;
@@ -905,7 +905,7 @@ class Invalidation {
 		$menu_term = get_term_by( 'term_taxonomy_id', absint( $tt_id ), $taxonomy );
 
 		// if the menu isn't public do nothing
-		if ( ! $menu_term || ! $this->is_menu_public( absint( $menu_term->term_id ) ) ) {
+		if ( ! isset( $menu_term->term_id ) || ! $this->is_menu_public( absint( $menu_term->term_id ) ) ) {
 			return;
 		}
 
@@ -923,12 +923,12 @@ class Invalidation {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function on_menu_item_updated_cb( int $menu_id, int $menu_item_db_id, array $args ): void  {
+	public function on_menu_item_updated_cb( int $menu_id, int $menu_item_db_id, array $args ): void {
 
 		$menu_term = get_term_by( 'term_id', absint( $menu_id ), 'nav_menu' );
 
 		// if the menu isn't public do nothing
-		if ( ! $menu_term || ! $this->is_menu_public( absint( $menu_term->term_id ) ) ) {
+		if ( ! isset( $menu_term->term_id ) || ! $this->is_menu_public( absint( $menu_term->term_id ) ) ) {
 			return;
 		}
 
@@ -944,7 +944,7 @@ class Invalidation {
 	 *
 	 * @return void
 	 */
-	public function on_menu_item_deleted_cb( int $post_id, WP_Post $post  ): void {
+	public function on_menu_item_deleted_cb( int $post_id, WP_Post $post ): void {
 
 		if ( 'nav_menu_item' !== $post->post_type ) {
 			return;

--- a/src/Cache/Invalidation.php
+++ b/src/Cache/Invalidation.php
@@ -108,6 +108,9 @@ class Invalidation {
 		add_action( 'deleted_term_meta', [ $this, 'on_updated_menu_meta_cb' ], 10, 4 );
 
 		// @todo: evict caches when meta on menu items are changed. This happens outside *_post_meta hooks as nav_menu_item is a "different" type of post type
+		add_action( 'added_term_relationship', [ $this, 'on_menu_item_added_to_menu_cb' ], 10, 3 );
+		add_action( 'wp_update_nav_menu_item', [ $this, 'on_menu_item_updated_cb' ], 10, 3 );
+		add_action( 'deleted_post', [ $this, 'on_menu_item_deleted_cb' ], 10, 2 );
 
 		add_action( 'updated_post_meta', [ $this, 'on_menu_item_change_cb' ], 10, 4 );
 		add_action( 'added_post_meta', [ $this, 'on_menu_item_change_cb' ], 10, 4 );
@@ -732,11 +735,6 @@ class Invalidation {
 			return;
 		}
 
-		// if the post type is not tracked, ignore it
-		if ( ! in_array( $post->post_type, \WPGraphQL::get_allowed_post_types(), true ) ) {
-			return;
-		}
-
 		$post_type_object = get_post_type_object( $post->post_type );
 
 		if ( ! $post_type_object instanceof \WP_Post_Type ) {
@@ -773,7 +771,7 @@ class Invalidation {
 	 * @return bool
 	 * @throws Exception
 	 */
-	public function is_menu_public( $menu_id ) {
+	public function is_menu_public( int $menu_id ): bool {
 		$nav_menu = get_term( $menu_id, 'nav_menu' );
 		if ( ! $nav_menu instanceof WP_Term ) {
 			return false;
@@ -825,8 +823,8 @@ class Invalidation {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function on_update_nav_menu_cb( $menu_id ) {
-		if ( ! $this->is_menu_public( $menu_id ) ) {
+	public function on_update_nav_menu_cb( int $menu_id ): void {
+		if ( ! $this->is_menu_public( absint( $menu_id ) ) ) {
 			return;
 		}
 
@@ -845,8 +843,8 @@ class Invalidation {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function on_create_nav_menu_cb( $menu_id, array $menu_data ) {
-		if ( ! $this->is_menu_public( $menu_id ) ) {
+	public function on_create_nav_menu_cb( int $menu_id, array $menu_data ) {
+		if ( ! $this->is_menu_public( absint( $menu_id ) ) ) {
 			return;
 		}
 
@@ -877,7 +875,7 @@ class Invalidation {
 		}
 
 		// if the menu isn't public do nothing
-		if ( ! $this->is_menu_public( $term->term_id ) ) {
+		if ( ! $this->is_menu_public( absint( $term->term_id ) ) ) {
 			return;
 		}
 
@@ -887,6 +885,79 @@ class Invalidation {
 
 		$this->purge_nodes( 'term', $term->term_id, 'menu_meta_updated' );
 	}
+
+	/**
+	 * Listen for when a term relationship has changed between nav_menu_item and nav_menu
+	 *
+	 * @param int    $object_id The ID of the object the taxonomy is associated with
+	 * @param int    $tt_id     The Term Taxonomy ID of the term
+	 * @param string $taxonomy  The name of the taxonomy the term belongs to
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function on_menu_item_added_to_menu_cb( int $object_id, int $tt_id, string $taxonomy  ): void {
+
+		if ( 'nav_menu' !== $taxonomy ) {
+			return;
+		}
+
+		$menu_term = get_term_by( 'term_taxonomy_id', absint( $tt_id ), $taxonomy );
+
+		// if the menu isn't public do nothing
+		if ( ! $menu_term || ! $this->is_menu_public( absint( $menu_term->term_id ) ) ) {
+			return;
+		}
+
+		$this->purge( 'list:menuitem', 'nav_menu_item_added' );
+
+	}
+
+	/**
+	 * Listen for when a menu item is updated
+	 *
+	 * @param int   $menu_id         ID of the updated menu.
+	 * @param int   $menu_item_db_id ID of the updated menu item.
+	 * @param array $args            An array of arguments used to update a menu item.
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function on_menu_item_updated_cb( int $menu_id, int $menu_item_db_id, array $args ): void  {
+
+		$menu_term = get_term_by( 'term_id', absint( $menu_id ), 'nav_menu' );
+
+		// if the menu isn't public do nothing
+		if ( ! $menu_term || ! $this->is_menu_public( absint( $menu_term->term_id ) ) ) {
+			return;
+		}
+
+		$this->purge_nodes( 'post', $menu_item_db_id, 'update_menu_item' );
+
+	}
+
+	/**
+	 * Listen for menu items being deleted and purge relevant caches
+	 *
+	 * @param int     $post_id The ID of the post being deleted
+	 * @param WP_Post $post The Post object that is being deleted
+	 *
+	 * @return void
+	 */
+	public function on_menu_item_deleted_cb( int $post_id, WP_Post $post  ): void {
+
+		if ( 'nav_menu_item' !== $post->post_type ) {
+			return;
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		$this->purge_nodes( 'post', $post->ID, 'nav_menu_item_deleted' );
+
+	}
+
 
 	/**
 	 * Listens for changes to meta for menu items

--- a/tests/wpunit/MenuCacheInvalidationTest.php
+++ b/tests/wpunit/MenuCacheInvalidationTest.php
@@ -49,7 +49,7 @@ class MenuCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataA
 		$this->assertEmpty( $this->getEvictedCaches() );
 
 		// assign the menu to a location. This should evict caches for queries for menus
-		set_theme_mod( 'nav_menu_locations', [ $location_name => (int) $this->menu->term_id ] );
+		set_theme_mod( 'nav_menu_locations', [ $location_name => (int) $this->public_menu->term_id ] );
 
 		$evicted_caches = $this->getEvictedCaches();
 
@@ -70,8 +70,8 @@ class MenuCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataA
 
 		$this->assertEmpty( $this->getEvictedCaches() );
 
-		wp_update_nav_menu_object( $this->menu->term_id, [
-			'menu-name' => $this->menu->name,
+		wp_update_nav_menu_object( $this->public_menu->term_id, [
+			'menu-name' => $this->public_menu->name,
 			'description' => 'updated description...',
 		] );
 
@@ -122,7 +122,7 @@ class MenuCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataA
 
 		$this->assertEmpty( $this->getEvictedCaches() );
 
-		wp_delete_nav_menu( $this->menu->term_id );
+		wp_delete_nav_menu( $this->public_menu->term_id );
 
 		$evicted = $this->getEvictedCaches();
 
@@ -134,7 +134,18 @@ class MenuCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataA
 			'singleMenu',
 
 			// deleting a menu that was in the listMenu results should evict the query
-			'listMenu'
+			'listMenu',
+
+			// deleting a menu that had this menu item in it should purge queries
+			// for this menu item as it will also delete this menu item
+			'singleChildMenuItem',
+
+			// deleting a menu that had this menu item in it should purge queries
+			// for this menu item as it will also delete this menu item
+			'singleMenuItem',
+
+			// Deleting a public menu should invalidate a query for a list of menuItems
+			'listMenuItem'
 		], $evicted );
 
 
@@ -159,7 +170,7 @@ class MenuCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataA
 		$this->assertEmpty( $this->getEvictedCaches() );
 
 		// update term meta on a public menu _should_ evict cache
-		update_term_meta( $this->menu->term_id, 'meta_key', uniqid( null, true ) );
+		update_term_meta( $this->public_menu->term_id, 'meta_key', uniqid( null, true ) );
 
 		$evicted = $this->getEvictedCaches();
 
@@ -179,7 +190,7 @@ class MenuCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataA
 	public function testDeleteTermMetaOnMenuAssignedToALocationEvictsCache() {
 
 		// setup some term meta to start with
-		update_term_meta( $this->menu->term_id, 'meta_key', uniqid( null, true ) );
+		update_term_meta( $this->public_menu->term_id, 'meta_key', uniqid( null, true ) );
 
 		// reset caches as the update above would have evicted some
 		$this->_populateCaches();
@@ -188,7 +199,7 @@ class MenuCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataA
 		$this->assertEmpty( $this->getEvictedCaches() );
 
 		// delete term meta on a public menu _should_ evict cache
-		delete_term_meta( $this->menu->term_id, 'meta_key' );
+		delete_term_meta( $this->public_menu->term_id, 'meta_key' );
 
 		$evicted = $this->getEvictedCaches();
 

--- a/tests/wpunit/MenuItemCacheInvalidationTest.php
+++ b/tests/wpunit/MenuItemCacheInvalidationTest.php
@@ -1,0 +1,140 @@
+<?php
+namespace WPGraphQL\SmartCache;
+
+use TestCase\WPGraphQLSmartCache\TestCase\WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches;
+
+class MenuItemCacheInvalidationTest extends WPGraphQLSmartCacheTestCaseWithSeedDataAndPopulatedCaches {
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->_populateCaches();
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+	}
+
+	public function testItWorks(): void {
+		$this->assertTrue( true );
+	}
+
+	// adding a new menu item to a menu that's assigned to a location should purge list:menuItem
+	public function testAddMenuItemToPublicMenuPurgesListMenuItem(): void {
+
+		// Create a new menu item
+		$new_nav_menu_item = self::factory()->post->create([
+			'post_type' => 'nav_menu_item',
+			'post_status' => 'publish',
+		]);
+
+		// Update nav menu item. This is ran when menu items are created and this generates
+		// the relationship between the menu item and menu
+		wp_update_nav_menu_item( $this->public_menu->term_id, $new_nav_menu_item, [
+			'menu-item-title' => 'New Public Menu Item',
+			'menu-item-object'    => 'page',
+			'menu-item-object-id' => $this->published_page->ID,
+			'menu-item-status'    => 'publish',
+			'menu-item-type'      => 'post_type',
+		]);
+
+		$evicted_caches = $this->getEvictedCaches();
+
+		$this->assertNotEmpty( $evicted_caches );
+
+		$this->assertEqualSets( $evicted_caches, [
+			'listMenuItem',
+		]);
+
+	}
+	// editing a menu item on a menu that's assigned to a location should purge the ID of said menu item
+	public function testUpdateMenuItemOnPublicMenuPurgesListMenuItem(): void {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		wp_update_nav_menu_item( $this->public_menu->term_id, $this->menu_item_1->ID, [
+			'menu-item-title' => 'Updated Menu Item Title',
+			'menu-item-description' => 'Updated Menu Item Description'
+		]);
+
+		$evicted_caches = $this->getEvictedCaches();
+
+		$this->assertNotEmpty( $evicted_caches );
+
+		$this->assertEqualSets( $evicted_caches, [
+			'listMenuItem',
+			'singleMenuItem'
+		]);
+
+	}
+	// removing a menu item on a menu that's assigned to a location should purge the ID of said menu item
+	public function testDeleteMenuItemOnPublicMenuPurgesListMenuItem(): void {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		wp_delete_nav_menu( $this->public_menu->term_id );
+
+		$evicted_caches = $this->getEvictedCaches();
+
+		$this->assertNotEmpty( $evicted_caches );
+
+		$this->assertEqualSets( $evicted_caches, [
+			'listMenuItem',
+			'singleMenuItem',
+			'listMenu',
+			'singleMenu',
+			'singleChildMenuItem'
+		]);
+
+	}
+
+	// adding a new menu item to a menu that's NOT assigned to a location should not emit a purge event
+	public function testAddMenuItemToPrivateMenuDoesNotPurgeCache(): void {
+
+		// Create a new menu item
+		$new_nav_menu_item = self::factory()->post->create([
+			'post_type' => 'nav_menu_item',
+			'post_status' => 'publish',
+		]);
+
+		wp_update_nav_menu_item( $this->private_menu->term_id, $new_nav_menu_item, [
+			'menu-item-title' => 'New Private Menu Item',
+			'menu-item-object'    => 'page',
+			'menu-item-object-id' => $this->published_page->ID,
+			'menu-item-status'    => 'publish',
+			'menu-item-type'      => 'post_type',
+		]);
+
+		$evicted_caches = $this->getEvictedCaches();
+
+		$this->assertEmpty( $evicted_caches );
+
+	}
+
+	// editing a menu item on a menu that's NOT assigned to a location should not emit a purge event
+	public function testUpdateMenuItemOnPrivateMenuDoesNotPurgeCaches(): void {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		wp_update_nav_menu_item( $this->private_menu->term_id, $this->private_menu_item->ID, [
+			'menu-item-title' => 'Updated Menu Item Title',
+			'menu-item-description' => 'Updated Menu Item Description'
+		]);
+
+		$evicted_caches = $this->getEvictedCaches();
+
+		$this->assertEmpty( $evicted_caches );
+
+	}
+
+	// removing a menu item on a menu that's NOT assigned to a location should not emit a purge event
+	public function testDeleteMenuItemOnPrivateMenuDoesNotPurgeCaches(): void {
+
+		$this->assertEmpty( $this->getEvictedCaches() );
+
+		wp_delete_nav_menu( $this->private_menu->term_id );
+
+		$evicted_caches = $this->getEvictedCaches();
+
+		$this->assertEmpty( $evicted_caches );
+
+	}
+
+}

--- a/tests/wpunit/PostCacheInvalidationTest.php
+++ b/tests/wpunit/PostCacheInvalidationTest.php
@@ -391,7 +391,7 @@ class PostCacheInvalidationTest extends \TestCase\WPGraphQLSmartCache\TestCase\W
 
 		// make assertions about the evicted caches
 		$this->assertNotEmpty( $evicted_caches );
-		
+
 		$this->assertEqualSets([
 			'userWithPostsConnection',
 			'singleCategory',

--- a/tests/wpunit/PostCacheInvalidationTest.php
+++ b/tests/wpunit/PostCacheInvalidationTest.php
@@ -364,6 +364,8 @@ class PostCacheInvalidationTest extends \TestCase\WPGraphQLSmartCache\TestCase\W
 			'singleNodeByUri',
 			'singleApprovedCommentByGlobalId',
 			'listComment',
+			'listMenuItem', // the single menu item is linked to the published post, so this query should be evicted because when the post is deleted it deletes the associated menu item
+			'singleMenuItem' // the single menu item is linked to the published post, so this query should be evicted because when the post is deleted it deletes the associated menu item
 		], $evicted_caches );
 	}
 
@@ -389,7 +391,7 @@ class PostCacheInvalidationTest extends \TestCase\WPGraphQLSmartCache\TestCase\W
 
 		// make assertions about the evicted caches
 		$this->assertNotEmpty( $evicted_caches );
-
+		
 		$this->assertEqualSets([
 			'userWithPostsConnection',
 			'singleCategory',
@@ -402,6 +404,8 @@ class PostCacheInvalidationTest extends \TestCase\WPGraphQLSmartCache\TestCase\W
 			'singlePost',
 			'singleApprovedCommentByGlobalId',
 			'listComment',
+			'listMenuItem', // the single menu item is linked to the published post, so this query should be evicted because when the post is deleted it deletes the associated menu item
+			'singleMenuItem' // the single menu item is linked to the published post, so this query should be evicted because when the post is deleted it deletes the associated menu item
 		], $evicted_caches );
 
 	}
@@ -576,7 +580,9 @@ class PostCacheInvalidationTest extends \TestCase\WPGraphQLSmartCache\TestCase\W
 		$this->assertEqualSets([
 			'listPage',
 			'singlePage',
-			'listContentNode'
+			'listContentNode',
+			'listMenuItem', // the menu item links to the published page
+			'singleChildMenuItem', // the menu item links to the published page
 		], $evicted_caches );
 
 	}


### PR DESCRIPTION
This adds event listeners for when menu items are created, updated and deleted to purge associated caches in response to said events.

- [x] failing tests:  https://github.com/wp-graphql/wp-graphql-smart-cache/actions/runs/7893082730
- [x] passing tests: https://github.com/wp-graphql/wp-graphql-smart-cache/actions/runs/7893092393

closes #260 