### PR TITLE
fix: restore whitespace rules for PHPCBF

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -65,7 +65,7 @@
 
 	<!-- Load WordPress VIP Go standards - for use with projects on the (newer) VIP Go platform. -->
 	<rule ref="WordPress-VIP-Go" />
-	
+
 	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
 
 	<rule ref="WordPress-Core">

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -65,7 +65,7 @@
 
 	<!-- Load WordPress VIP Go standards - for use with projects on the (newer) VIP Go platform. -->
 	<rule ref="WordPress-VIP-Go" />
-
+	
 	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
 
 	<rule ref="WordPress-Core">
@@ -109,4 +109,14 @@
 	<!-- Enforce short array syntax -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
+	<!-- These formatting rules are suppressed in VIP-GO and restored here.-->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine">
+		<severity>5</severity>
+	</rule>
 </ruleset>

--- a/src/Admin/Editor.php
+++ b/src/Admin/Editor.php
@@ -46,12 +46,12 @@ class Editor {
 	public function untrashed_post_cb( $post_id, $previous_status ) {
 		// If have errors when validating the post content/data, do not show those in the admin when untrash.
 		$untrashed_post = get_post( $post_id );
-		
+
 		// Bail if the untrashed post is not a GraphQL Document
 		if ( ! isset( $untrashed_post->post_type ) || Document::TYPE_NAME !== $untrashed_post->post_type ) {
 			return;
 		}
-	
+
 		delete_transient( AdminErrors::TRANSIENT_NAME );
 	}
 


### PR DESCRIPTION
This PR restores some rules that auto-format trailing whitespace and newlines in PHPCBF. I copied the code from: https://github.com/AxeWP/WPGraphQL-Coding-Standards/commit/23dbbaf8f91c4cb596116c4c5415b4e70c5b50f7 (thanks @justlevine)

## Before

Example from before these rules are reintroduced; the formatter ignores these spacing issues:

<img width="648" alt="image" src="https://github.com/user-attachments/assets/fc19b52a-dee9-4db4-b343-e018d1ce537d">

## After

With the rules reintroduced, the file is formatted as expected, with extraneous whitespace removed:

<img width="582" alt="image" src="https://github.com/user-attachments/assets/8009846b-6576-4681-ab3c-91e4ee057a0e">

## Note

I attempted to try installing WPGraphQL CS from [here](https://github.com/AxeWP/WPGraphQL-Coding-Standards?tab=readme-ov-file#installation) using `composer require --dev axepress/wp-graphql-cs` to see if we could use a single source of rulesets, but I ran into this error:

<img width="525" alt="image" src="https://github.com/user-attachments/assets/1a150c5a-fb34-4987-bd52-35b305a702e2">

I'm not sure if it's worth pursuing to use the single code rule source, or if it's a rabbit hole I shouldn't venture down right now. Open to ideas. Thanks!