### PR TITLE
fix: queryid not returning X-GraphQL-Keys headers

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -206,12 +206,12 @@ class Document {
 	public function graphql_query_contains_query_id_cb( $parsed_body_params, $request_context ) {
 
 		// Normalize keys to handle both `queryId` and `queryid`.
-		$query_id_key = isset($parsed_body_params['queryId']) ? 'queryId' : (isset($parsed_body_params['queryid']) ? 'queryid' : null);
+		$query_id_key = isset( $parsed_body_params['queryId'] ) ? 'queryId' : ( isset( $parsed_body_params['queryid'] ) ? 'queryid' : null );
 
 		// If both query and queryId/queryid are set
 		if ( ! empty( $parsed_body_params['query'] ) && ! empty( $query_id_key ) ) {
 			// Save the query
-			$this->save( $parsed_body_params[$query_id_key], $parsed_body_params['query'] );
+			$this->save( $parsed_body_params[ $query_id_key ], $parsed_body_params['query'] );
 
 			// Remove it from processed body params so graphql-php operation proceeds without conflict.
 			unset( $parsed_body_params['query'] );
@@ -219,11 +219,11 @@ class Document {
 
 		// If the query is empty, but queryId/queryid is set
 		if ( empty( $parsed_body_params['query'] ) && ! empty( $query_id_key ) ) {
-			$query_string = $this->get( $parsed_body_params[$query_id_key] );
+			$query_string = $this->get( $parsed_body_params[ $query_id_key ] );
 			if ( ! empty( $query_string ) ) {
 				$parsed_body_params['query']           = $query_string;
-				$parsed_body_params['originalQueryId'] = $parsed_body_params[$query_id_key];
-				unset( $parsed_body_params[$query_id_key] );
+				$parsed_body_params['originalQueryId'] = $parsed_body_params[ $query_id_key ];
+				unset( $parsed_body_params[ $query_id_key ] );
 			}
 		}
 

--- a/src/Document.php
+++ b/src/Document.php
@@ -195,34 +195,35 @@ class Document {
 
 	/**
 	 * Process request looking for when queryid and query are present.
-	 * Save the query and remove it from the request
+	 * Save the query and remove it from the request.
 	 *
 	 * @param  array $parsed_body_params Request parameters.
-	 * @param  array $request_context An array containing the both body and query params
+	 * @param  array $request_context An array containing both body and query params.
 	 *
 	 * @return array Updated $parsed_body_params Request parameters.
 	 * @throws RequestError
 	 */
 	public function graphql_query_contains_query_id_cb( $parsed_body_params, $request_context ) {
 
-		// if both query and queryId are set
-		// we should attempt to save the query document (per APQ)
-		if ( ! empty( $parsed_body_params['query'] ) && ! empty( $parsed_body_params['queryId'] ) ) {
-			// save the query
-			// The query string already coming from 'graphql_request_data' already has the query string unslashed.
-			$this->save( $parsed_body_params['queryId'], $parsed_body_params['query'] );
+		// Normalize keys to handle both `queryId` and `queryid`.
+		$query_id_key = isset($parsed_body_params['queryId']) ? 'queryId' : (isset($parsed_body_params['queryid']) ? 'queryid' : null);
 
-			// remove it from process body params so graphql-php operation proceeds without conflict.
+		// If both query and queryId/queryid are set
+		if ( ! empty( $parsed_body_params['query'] ) && ! empty( $query_id_key ) ) {
+			// Save the query
+			$this->save( $parsed_body_params[$query_id_key], $parsed_body_params['query'] );
+
+			// Remove it from processed body params so graphql-php operation proceeds without conflict.
 			unset( $parsed_body_params['query'] );
 		}
 
-		// if the query is empty, but the queryId is set
-		if ( empty( $parsed_body_params['query'] ) && ! empty( $parsed_body_params['queryId'] ) ) {
-			$query_string = $this->get( $parsed_body_params['queryId'] );
+		// If the query is empty, but queryId/queryid is set
+		if ( empty( $parsed_body_params['query'] ) && ! empty( $query_id_key ) ) {
+			$query_string = $this->get( $parsed_body_params[$query_id_key] );
 			if ( ! empty( $query_string ) ) {
 				$parsed_body_params['query']           = $query_string;
-				$parsed_body_params['originalQueryId'] = $parsed_body_params['queryId'];
-				unset( $parsed_body_params['queryId'] );
+				$parsed_body_params['originalQueryId'] = $parsed_body_params[$query_id_key];
+				unset( $parsed_body_params[$query_id_key] );
 			}
 		}
 
@@ -230,22 +231,26 @@ class Document {
 	}
 
 	/**
-	 * During invoking 'graphql()', not as an http request, if queryId is present, look it up and return the query string
+	 * During invoking 'graphql()', not as an HTTP request, if queryId is present, look it up and return the query string.
 	 *
 	 * @param string $query  The graphql query string.
-	 * @param mixed|array|\GraphQL\Server\OperationParams $params  The graphql request params, containing queryId
+	 * @param mixed|array|\GraphQL\Server\OperationParams $params  The graphql request params, potentially containing queryId.
 	 *
 	 * @return string|null
 	 */
 	public function graphql_execute_query_params_cb( $query, $params ) {
 		$query_id = null;
 		if ( empty( $query ) ) {
-			//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			// Check both camelCase and lowercase query ID
 			if ( isset( $params->queryId ) ) {
 				//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$query_id = $params->queryId;
-			} elseif ( is_array( $params ) && isset( $params['queryId'] ) ) {
-				$query_id = $params['queryId'];
+			} elseif ( is_array( $params ) ) {
+				if ( isset( $params['queryid'] ) ) {
+					$query_id = $params['queryid'];
+				} elseif ( isset( $params['queryId'] ) ) {
+					$query_id = $params['queryId'];
+				}
 			}
 
 			if ( ! empty( $query_id ) ) {


### PR DESCRIPTION
This fixes a bug where using all lowercase `queryid` as a GET param would execute the query but would not include the X-GraphQL-Keys in the response, preventing the documents from being properly tagged in the cache and thus not being invalidated from the cache properly.

## Before

Executing a GET request with `queryid` as the query param leads to X-GraphQL-Keys being excluded from the response

![CleanShot 2024-08-29 at 14 12 02](https://github.com/user-attachments/assets/14d717dc-c6f4-44ab-bbfc-68c9407f47ae)

## After

Now using lowercase `queryid` or camelcase `queryId` both work and return the X-GraphQL-Keys:

`queryid`:

![CleanShot 2024-08-29 at 14 10 26](https://github.com/user-attachments/assets/938d1b6e-f24b-4fc3-b933-fd53e6c07baf)

`queryId`:

![CleanShot 2024-08-29 at 14 13 43](https://github.com/user-attachments/assets/9314e34b-5ea7-4d45-8d91-c68a0cb33995)

----

closes: #293 